### PR TITLE
new thin client + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ sumo.get(f"/objects('{object_id}')")
 
 For a full list of available endpoints, visit:
 
-- Prod: https://main-sumo-prod.radix.equinor.com/swagger-ui
-- Dev: https://main-sumo-dev.radix.equinor.com/swagger-ui
-- Test: https://main-sumo-test.radix.equinor.com/swagger-ui
-- Preview: https://main-sumo-preview.radix.equinor.com/swagger-ui
+- Prod: https://main-sumo-prod.radix.equinor.com/swagger-ui/
+- Dev: https://main-sumo-dev.radix.equinor.com/swagger-ui/
+- Test: https://main-sumo-test.radix.equinor.com/swagger-ui/
+- Preview: https://main-sumo-preview.radix.equinor.com/swagger-ui/
 
 ### get(path, **params)
 Performs a GET-request to sumo-core. Accepts query parameters as keyword arguments.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For internal Equinor users, this package is available through the Komodo distrib
   - [Examples](#examples)
     - [search()](#search)
     - [searchroot()](#searchroot)
-- [SumoThinClient](#sumothinclient)
+- [SumoClient](#SumoClient)
     - [Initialization](#initialization)
     - [Parameters](#parameters)
   - [Methods](#methods)
@@ -109,21 +109,21 @@ peesv_objects = sumo.searchroot(
 )
 ```
 
-# SumoThinClient
+# SumoClient
 An ultra thin wrapper class.
 
 ### Initialization
 
 ```python
-from sumo.wrapper import SumoThinClient
+from sumo.wrapper import SumoClient
 
-sumo = SumoThinClient(env="dev")
+sumo = SumoClient(env="dev")
 ```
 
 ### Parameters
 
 ```python
-class SumoThinClient:
+class SumoClient:
     def __init__(
         self,
         env,
@@ -143,7 +143,7 @@ class SumoThinClient:
 If no `access_token` is provided, an authentication code flow is triggered to retrieve a token.
 
 ## Methods
-`SumoThinClient` has one method for each HTTP-method that is used in the sumo-core API. See examples of how to use these methods below.
+`SumoClient` has one method for each HTTP-method that is used in the sumo-core API. See examples of how to use these methods below.
 
 
 All methods accepts a path argument. Path parameters can be interpolated into the path string. Example:
@@ -153,13 +153,6 @@ object_id = "1234"
 # GET/objects('{obejctid}')
 sumo.get(f"/objects('{object_id}')")
 ```
-
-For a full list of available endpoints, visit:
-
-- Prod: https://main-sumo-prod.radix.equinor.com/swagger-ui/
-- Dev: https://main-sumo-dev.radix.equinor.com/swagger-ui/
-- Test: https://main-sumo-test.radix.equinor.com/swagger-ui/
-- Preview: https://main-sumo-preview.radix.equinor.com/swagger-ui/
 
 ### get(path, **params)
 Performs a GET-request to sumo-core. Accepts query parameters as keyword arguments.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ object_id = "1234"
 sumo.get(f"/objects('{object_id}')")
 ```
 
-Full a full list of available endpoints, visit:
+For a full list of available endpoints, visit:
 
 - Prod: https://main-sumo-prod.radix.equinor.com/swagger-ui
 - Dev: https://main-sumo-dev.radix.equinor.com/swagger-ui

--- a/README.md
+++ b/README.md
@@ -1,8 +1,217 @@
 # sumo-wrapper-python
 Python wrappers for Sumo APIs
 
-## Install by running: 
+## Install: 
     
     pip install git+ssh://git@github.com/equinor/sumo-wrapper-python.git@master
 
 For internal Equinor users, this package is available through the Komodo distribution.
+
+# Table of contents
+
+- [CallSumoApi](#callsumoapi)
+    - [Initialization](#initialization)
+    - [Parameters](#parameters)
+  - [Examples](#examples)
+    - [search()](#search)
+    - [searchroot()](#searchroot)
+- [SumoThinClient](#sumothinclient)
+    - [Initialization](#initialization)
+    - [Parameters](#parameters)
+  - [Methods](#methods)
+    - [get(path, **params)](#getpath-params)
+    - [post(path, json, blob)](#postpath-json-blob)
+    - [put(path, json, blob)](#putpath-json-blob)
+    - [delete(path)](#deletepath)
+
+# CallSumoApi
+Predefined methods for various sumo operations. I.e uploading, searching for and deleting metadata and blobs.
+
+### Initialization
+```python
+from sumo.wrapper import CallSumoApi
+
+sumo = CallSumoApi()
+```
+
+### Parameters
+```python
+class CallSumoApi:
+    def __init__(
+        self,
+        env="dev",
+        resource_id=None,
+        client_id=None,
+        outside_token=False,
+        writeback=False,
+    ):
+```
+
+## Examples
+All `CallSumoApi` methods accept a `bearer` argument which lets the user use an existing access token instead of generating a new one.
+
+### search()
+Search all objects in sumo.
+
+#### Parameters
+```python
+def search(
+    self,
+    query,
+    select=None,
+    buckets=None,
+    search_from=0,
+    search_size="100",
+    search_after=None,
+    bearer=None,
+):
+```
+
+#### Usage
+```python
+# Find objects where class = surface
+search_results = sumo.search(query="class:surface", search_size="10")
+
+# Get child objects for a specific object
+parent_id = "1234"
+children = sumo.search(query=f"_sumo.parent_object:{parent_id}")
+
+# Get buckets for child object classes (i.e surface, table, polygon)
+# This will return a count for every class value
+buckets = sumo.search(
+    query=f"_sumo.parent_object:{parent_id}",
+    buckets=["class.keyword"]
+)
+```
+
+### searchroot()
+Search for parent objects (object without parent)
+
+#### Parameters
+```python
+def searchroot(
+    self,
+    query,
+    select=None,
+    buckets=None,
+    search_from=0,
+    search_size="100",
+    bearer=None,
+):
+```
+
+#### Usage
+```python
+# Get 3 top level objects for a specific user
+peesv_objects = sumo.searchroot(
+    query="fmu.case.user.id:peesv", 
+    search_size=3
+)
+```
+
+# SumoThinClient
+An ultra thin wrapper class.
+
+### Initialization
+
+```python
+from sumo.wrapper import SumoThinClient
+
+sumo = SumoThinClient(env="dev")
+```
+
+### Parameters
+
+```python
+class SumoThinClient:
+    def __init__(
+        self,
+        env,
+        access_token=None,
+        logging_level='INFO',
+        write_back=False
+    ):
+```
+- `env*` (string) - sumo environment
+
+- `logging_level` (string) - logging level: "INFO", "DEBUG", "WARNING", "ERROR"
+
+- `access_token` (string) - bearer token for authentication
+
+- `write_back` (boolean) - update token cache
+
+If no `access_token` is provided, an authentication code flow is triggered to retrieve a token.
+
+## Methods
+`SumoThinClient` has one method for each HTTP-method that is used in the sumo-core API. See examples of how to use these methods below.
+
+
+All methods accepts a path argument. Path parameters can be interpolated into the path string. Example:
+```python
+object_id = "1234"
+
+# GET/objects('{obejctid}')
+sumo.get(f"/objects('{object_id}')")
+```
+
+Full a full list of available endpoints, visit:
+
+- Prod: https://main-sumo-prod.radix.equinor.com/swagger-ui
+- Dev: https://main-sumo-dev.radix.equinor.com/swagger-ui
+- Test: https://main-sumo-test.radix.equinor.com/swagger-ui
+- Preview: https://main-sumo-preview.radix.equinor.com/swagger-ui
+
+### get(path, **params)
+Performs a GET-request to sumo-core. Accepts query parameters as keyword arguments.
+
+```python
+# Retrieve userdata
+user_data = sumo.get("/userdata")
+
+# Search for objects
+results = sumo.get("/search", 
+    query="class:surface", 
+    size:3, 
+    select=["_id"]
+)
+
+# Get object by id
+object_id = "159405ba-0046-b321-55ce-542f383ba5c7"
+
+obj = sumo.get(f"/objects('{object_id}')")
+```
+
+
+### post(path, json, blob)
+Performs a POST-request to sumo-core. Accepts json and blob, but not both at the same time. 
+```python
+# Upload new parent object
+parent_object = sumo.post("/objects", json=parent_meta_data)
+
+# Upload child object
+parent_id = parent_object["_id"]
+
+child_object = sumo.post(f"/objects('{parent_id}')", json=child_meta_data)
+```
+
+### put(path, json, blob)
+Performs a PUT-request to sumo-core. Accepts json and blob, but not both at the same time.
+```python
+# Upload blob to child object
+child_id = child_object["_id"]
+
+sumo.put(f"/objects('{child_id}')/blob", blob=blob)
+```
+
+### delete(path)
+Performs a DELETE-request to sumo-core.
+```python
+# Delete blob
+sumo.delete(f"/objects('{child_id}')/blob")
+
+# Delete child object
+sumo.delete(f"/objects('{child_id}')")
+
+# Delete parent object
+sumo.delete(f"/objects('{parent_id}')")
+```

--- a/src/sumo/wrapper/__init__.py
+++ b/src/sumo/wrapper/__init__.py
@@ -1,2 +1,2 @@
 from ._call_sumo_api import CallSumoApi
-from ._thin_client import SumoThinClient
+from ._sumo_client import SumoClient

--- a/src/sumo/wrapper/__init__.py
+++ b/src/sumo/wrapper/__init__.py
@@ -1,1 +1,2 @@
 from ._call_sumo_api import CallSumoApi
+from ._thin_client import SumoThinClient

--- a/src/sumo/wrapper/_sumo_client.py
+++ b/src/sumo/wrapper/_sumo_client.py
@@ -11,7 +11,7 @@ logging.basicConfig(
 )
 
 
-class SumoThinClient:
+class SumoClient:
     def __init__(
         self,
         env,

--- a/src/sumo/wrapper/_thin_client.py
+++ b/src/sumo/wrapper/_thin_client.py
@@ -1,0 +1,177 @@
+import requests
+import logging
+
+from .config import APP_REGISTRATION, TENANT_ID, AUTHORITY_HOST_URI
+from ._auth import Auth
+from ._request_error import AuthenticationError, TransientError, PermanentError
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+
+class SumoThinClient:
+    def __init__(
+        self,
+        env,
+        access_token=None,
+        logging_level='INFO',
+        write_back=False
+    ):
+        self.env = env
+        self.user_provided_access_token = access_token
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(level=logging_level)
+
+        if env not in APP_REGISTRATION:
+            raise ValueError(f"Invalid environment: {env}")
+
+        self.client_id = APP_REGISTRATION[env]['CLIENT_ID']
+        self.resource_id = APP_REGISTRATION[env]['RESOURCE_ID']
+        self.authority_uri = AUTHORITY_HOST_URI + '/' + TENANT_ID
+
+        if not self.user_provided_access_token:
+            self.auth = Auth(
+                client_id=self.client_id,
+                resource_id=self.resource_id,
+                authority=self.authority_uri,
+                writeback=write_back,
+                logging_level=logging_level
+            )
+
+            self.access_token = self.auth.get_token()
+
+        if env == "localhost":
+            self.base_url = f"http://localhost:8084/api/v1"
+        else:
+            self.base_url = f"https://main-sumo-{env}.radix.equinor.com/api/v1"
+
+    def _retrieve_token(self):
+        if self.user_provided_access_token:
+            self.logger.debug("User provided token exists, returning token")
+            return self.user_provided_access_token
+        else:
+            if self.auth.is_token_expired():
+                self.logger.debug("Token is expired, regenerating")
+                self.access_token = self.auth.get_token()
+
+        self.logger.debug("returning self.access_token from _retrieve_token")
+        return self.access_token
+
+    def get(self, path, params=None):
+        token = self._retrieve_token()
+
+        headers = {
+            "Content-Type": "application/json",
+            "authorization": f'Bearer {token}'
+        }
+
+        response = requests.get(
+            f'{self.base_url}{path}',
+            params=params,
+            headers=headers
+        )
+
+        if not response.ok:
+            self._raise_request_error_exception(
+                response.status_code, response.text)
+
+        if "/blob" in path:
+            return response.content
+
+        return response.json()
+
+    def post(self, path, blob=None, json=None):
+        token = self._retrieve_token()
+
+        if blob and json:
+            raise ValueError(
+                "Both blob and json given to post - can only have one at the time.")
+
+        content_type = "application/json" if json is not None else "application/octet-stream"
+
+        headers = {
+            "Content-Type": content_type,
+            "authorization": f'Bearer {token}',
+            "Content-Length": str(len(json) if json else len(blob)),
+        }
+
+        try:
+            response = requests.post(
+                f'{self.base_url}{path}',
+                data=blob,
+                json=json,
+                headers=headers
+            )
+        except requests.exceptions.ProxyError as err:
+            self._raise_request_error_exception(503, err)
+
+        if not response.ok:
+            self._raise_request_error_exception(
+                response.status_code, response.text)
+
+        return response
+
+    def put(self, path, blob=None, json=None):
+        token = self._retrieve_token()
+
+        if blob and json:
+            raise ValueError(
+                "Both blob and json given to post - can only have one at the time.")
+
+        content_type = "application/json" if json is not None else "application/octet-stream"
+
+        headers = {
+            "Content-Type": content_type,
+            "authorization": f'Bearer {token}',
+            "Content-Length": str(len(json) if json else len(blob)),
+        }
+
+        try:
+            response = requests.put(
+                f'{self.base_url}{path}',
+                data=blob,
+                json=json,
+                headers=headers
+            )
+        except requests.exceptions.ProxyError as err:
+            self. _raise_request_error_exception(503, err)
+
+        if not response.ok:
+            self._raise_request_error_exception(
+                response.status_code, response.text)
+
+        return response
+
+    def delete(self, path):
+        token = self._retrieve_token()
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f'Bearer {token}',
+        }
+
+        response = requests.delete(f'{self.base_url}{path}', headers=headers)
+
+        if not response.ok:
+            self._raise_request_error_exception(
+                response.status_code, response.text)
+
+        return response.json()
+
+    def _raise_request_error_exception(self, code, message):
+        """
+        Raise the proper authentication error according to the code received from sumo.
+        """
+
+        self.logger.debug("code: %s", code)
+        self.logger.debug("message: %s", message)
+
+        if 503 <= code <= 504 or code == 404 or code == 500:
+            raise TransientError(code, message)
+        elif 401 <= code <= 403:
+            raise AuthenticationError(code, message)
+        else:
+            raise PermanentError(code, message)

--- a/src/sumo/wrapper/_thin_client.py
+++ b/src/sumo/wrapper/_thin_client.py
@@ -37,8 +37,7 @@ class SumoThinClient:
                 client_id=self.client_id,
                 resource_id=self.resource_id,
                 authority=self.authority_uri,
-                writeback=write_back,
-                logging_level=logging_level
+                writeback=write_back
             )
 
             self.access_token = self.auth.get_token()
@@ -60,7 +59,16 @@ class SumoThinClient:
         self.logger.debug("returning self.access_token from _retrieve_token")
         return self.access_token
 
-    def get(self, path, params=None):
+    def _process_params(self, params_dict):
+        prefixed_params = {}
+
+        for param_key in params_dict:
+            prefixed_params[f"${param_key}"] = params_dict[param_key]
+
+        return None if prefixed_params == {} else prefixed_params
+
+
+    def get(self, path, **params):
         token = self._retrieve_token()
 
         headers = {
@@ -70,7 +78,7 @@ class SumoThinClient:
 
         response = requests.get(
             f'{self.base_url}{path}',
-            params=params,
+            params=self._process_params(params),
             headers=headers
         )
 

--- a/src/sumo/wrapper/config.py
+++ b/src/sumo/wrapper/config.py
@@ -11,10 +11,16 @@ APP_REGISTRATION = {
         "CLIENT_ID" : '1826bd7c-582f-4838-880d-5b4da5c3eea2',
         "RESOURCE_ID" : '88d2b022-3539-4dda-9e66-853801334a86'
         },
+    "preview": {
+        "CLIENT_ID": '1826bd7c-582f-4838-880d-5b4da5c3eea2',
+        "RESOURCE_ID": '88d2b022-3539-4dda-9e66-853801334a86'
+    },
     "localhost" : {
         "CLIENT_ID" : '1826bd7c-582f-4838-880d-5b4da5c3eea2',
         "RESOURCE_ID" : '88d2b022-3539-4dda-9e66-853801334a86'
         }
-
     }
 
+TENANT_ID = '3aa4a235-b6e2-48d5-9195-7fcf05b459b0'
+
+AUTHORITY_HOST_URI = 'https://login.microsoftonline.com'

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -123,20 +123,14 @@ def test_upload_search_delete_ensemble_child():
     # Search for ensemble
     query = f"{fmu_case_id}"
 
-    search_results = C.api.get("/searchroot", {
-        "$query": query,
-        "$select": ["_source"]
-    })
+    search_results = C.api.get("/searchroot", query=query, select=["_source"])
 
     hits = search_results.get("hits").get("hits")
     assert len(hits) == 1
     assert hits[0].get("_id") == case_id
 
     # Search for child object
-    search_results = C.api.get("/search", {
-        "$query": query,
-        "$select": ["_source"]
-    })
+    search_results = C.api.get("/search", query=query, select=["_source"])
 
     total = search_results.get("hits").get("total").get("value")
     assert total == 2
@@ -155,20 +149,14 @@ def test_upload_search_delete_ensemble_child():
     sleep(4)
 
     # Search for ensemble
-    search_results = C.api.get("/searchroot", {
-        "$query": query,
-        "$select": ["_source"]
-    })
+    search_results = C.api.get("/searchroot", query=query, select=["_source"])
 
     hits = search_results.get("hits").get("hits")
 
     assert len(hits) == 0
 
     # Search for child object
-    search_results = C.api.get("/search", {
-        "$query": query,
-        "$select": ["_source"]
-    })
+    search_results = C.api.get("/search", query=query, select=["_source"])
     total = search_results.get("hits").get("total").get("value")
     assert total == 0
 

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -1,0 +1,218 @@
+"""Example code for communicating with Sumo"""
+
+import pytest
+import yaml
+from time import sleep
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join('src')))
+
+from sumo.wrapper import SumoThinClient
+
+
+class Connection:
+    def __init__(self):
+        self.api = SumoThinClient(env="preview", logging_level="DEBUG")
+
+
+def _upload_parent_object(C, json):
+    response = C.api.post("/objects", json=json)
+
+    if not 200 <= response.status_code < 202:
+        raise Exception(f"code: {response.status_code}, text: {response.text}")
+    return response
+
+
+def _upload_blob(C, blob, url=None, object_id=None):
+    response = C.api.put(f"/objects('{object_id}')/blob", blob=blob)
+
+    print("Blob save " + str(response.status_code), flush=True)
+    if not 200 <= response.status_code < 202:
+        raise Exception(
+            f"blob upload to object_id {object_id} returned {response.text} {response.status_code}"
+        )
+    return response
+
+
+def _get_blob_uri(C, object_id):
+    response = C.api.get(f"/objects('{object_id}')/blob/authuri")
+
+    print("Blob save " + str(response.status_code), flush=True)
+    if not 200 <= response.status_code < 202:
+        raise Exception(
+            f"get blob uri for {object_id} returned {response.text} {response.status_code}"
+        )
+    return response
+
+
+def _download_object(C, object_id):
+    json = C.api.get(f"/objects('{object_id}')")
+
+    return json
+
+
+def _upload_child_level_json(C, parent_id, json):
+    response = C.api.post(f"/objects('{parent_id}')", json=json)
+
+    if not 200 <= response.status_code < 202:
+        raise Exception(
+            f"Response: {response.status_code}, Text: {response.text}")
+    return response
+
+
+def _delete_object(C, object_id):
+    response = C.api.delete(f"/objects('{object_id}')")
+
+    return response
+
+
+class ValueKeeper:
+    """Class for keeping/passing values between tests"""
+
+    pass
+
+
+""" TESTS """
+
+
+def test_upload_search_delete_ensemble_child():
+    """
+    Testing the wrapper functionalities.
+
+    We upload an ensemble object along with a child. After that, we search for
+    those objects to make sure they are available to the user. We then delete
+    them and repeat the search to check if they were properly removed from sumo.
+    """
+    C = Connection()
+    B = b"123456789"
+
+    # Upload Ensemble
+    with open("tests/testdata/case.yml", "r") as stream:
+        fmu_case_metadata = yaml.safe_load(stream)
+
+    response_case = _upload_parent_object(C=C, json=fmu_case_metadata)
+
+    assert 200 <= response_case.status_code <= 202
+    assert isinstance(response_case.json(), dict)
+
+    case_id = response_case.json().get("objectid")
+    fmu_case_id = fmu_case_metadata.get("fmu").get("case").get("uuid")
+
+    # Upload Regular Surface
+    with open("tests/testdata/surface.yml", "r") as stream:
+        fmu_surface_metadata = yaml.safe_load(stream)
+
+    fmu_surface_id = fmu_surface_metadata.get(
+        "fmu").get("realization").get("id")
+    response_surface = _upload_child_level_json(
+        C=C, parent_id=case_id, json=fmu_surface_metadata
+    )
+
+    assert 200 <= response_surface.status_code <= 202
+    assert isinstance(response_surface.json(), dict)
+
+    surface_id = response_surface.json().get("objectid")
+
+    # Upload BLOB
+    response_blob = _upload_blob(C=C, blob=B, object_id=surface_id)
+    assert 200 <= response_blob.status_code <= 202
+
+    sleep(4)
+
+    # Search for ensemble
+    query = f"{fmu_case_id}"
+
+    search_results = C.api.get("/searchroot", {
+        "$query": query,
+        "$select": ["_source"]
+    })
+
+    hits = search_results.get("hits").get("hits")
+    assert len(hits) == 1
+    assert hits[0].get("_id") == case_id
+
+    # Search for child object
+    search_results = C.api.get("/search", {
+        "$query": query,
+        "$select": ["_source"]
+    })
+
+    total = search_results.get("hits").get("total").get("value")
+    assert total == 2
+
+    get_result = _download_object(C, object_id=surface_id)
+    assert get_result["_id"] == surface_id
+
+    # Search for blob
+    bin_obj = C.api.get(f"/objects('{surface_id}')/blob")
+    assert bin_obj == B
+
+    # Delete Ensemble
+    result = _delete_object(C=C, object_id=case_id)
+    assert result == "Accepted"
+
+    sleep(4)
+
+    # Search for ensemble
+    search_results = C.api.get("/searchroot", {
+        "$query": query,
+        "$select": ["_source"]
+    })
+
+    hits = search_results.get("hits").get("hits")
+
+    assert len(hits) == 0
+
+    # Search for child object
+    search_results = C.api.get("/search", {
+        "$query": query,
+        "$select": ["_source"]
+    })
+    total = search_results.get("hits").get("total").get("value")
+    assert total == 0
+
+
+def test_fail_on_wrong_metadata():
+    """
+    Upload a parent object with erroneous metadata, confirm failure
+    """
+    C = Connection()
+    with pytest.raises(Exception):
+        assert _upload_parent_object(C=C, json={"some field": "some value"})
+
+
+def test_upload_duplicate_ensemble():
+    """
+    Adding a duplicate ensemble, both tries must return same id.
+    """
+    C = Connection()
+
+    with open("tests/testdata/case.yml", "r") as stream:
+        fmu_metadata1 = yaml.safe_load(stream)
+
+    with open("tests/testdata/case.yml", "r") as stream:
+        fmu_metadata2 = yaml.safe_load(stream)
+
+    # upload case metadata, get object_id
+    response1 = _upload_parent_object(C=C, json=fmu_metadata1)
+    assert 200 <= response1.status_code <= 202
+
+    # upload duplicated case metadata, get object_id
+    response2 = _upload_parent_object(C=C, json=fmu_metadata2)
+    assert 200 <= response2.status_code <= 202
+
+    case_id1 = response1.json().get("objectid")
+    case_id2 = response2.json().get("objectid")
+    assert case_id1 == case_id2
+
+    get_result = _download_object(C, object_id=case_id1)
+    assert get_result["_id"] == case_id1
+
+    # Delete Ensemble
+    result = _delete_object(C=C, object_id=case_id1)
+    assert result == "Accepted"
+
+    # Search for ensemble
+    with pytest.raises(Exception):
+        assert _download_object(C, object_id=case_id2)


### PR DESCRIPTION
New ultra thin wrapper class.

## Example:
```python
from sumo.wrapper import SumoThinClient

sumo = SumoThinClient(env="preview")

# GET/search
search = sumo.get("/search", query="class:case", size=3, select=["_id"])

# GET/objects('{objectid}')
object_id = "159405ba-0046-b321-55ce-542f383ba5c7"
obj = sumo.get(f"/objects('{object_id}')")
```

## Notes:

### get(): Return result.json vs result.content

`SumoThinClient.get` returns `result.content` if the path contains `/blob` and `result.json` otherwise. This might not be a sufficient way to handle the cases where we don't wan't to return json.

`CallAzureApi` solves this by having to methods: `get_json` and `get_content`. Should `SumoThinClient` do the same? Alternatively it could take an additional parameter, i.e `return_content` that is `False` by default


### post(): json vs blob

Just like `CallAzureApi`, this method accepts `json` and `blob` but will raise an error if both are present. Is this sufficient, or should we have two methods? I.e `post_json` and `post_blob`


### User provided access_token + authentication flow

`SumoThinClient` takes an optional `access_token`-parameter in the constructor and will only create an instance of the `Auth` class if this parameter is not present. The existing wrapper always creates an `Auth` object in the constructor and takes a `bearer` parameter in every request method.

Should we avoid triggering the authentication logic if the user has provided their own token?
And should they send the token in the constructor or with every request?