### PR TITLE
add access_token parameters

### DIFF
--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -13,7 +13,7 @@ from sumo.wrapper import SumoClient
 
 class Connection:
     def __init__(self):
-        self.api = SumoClient(env="dev", logging_level="DEBUG")
+        self.api = SumoClient(env="dev", logging_level="DEBUG", authentication_enabled=True)
 
 
 def _upload_parent_object(C, json):


### PR DESCRIPTION
- Remove `access_token` parameter from constructor
- Add `access_token` parameter to get/post/put/delete methods

Added a new constructor parameter: `authentication_enabled`. If this parameter is `True` the `SumoClient` object  will initialize an `Auth` object to retrieve an access token using device_code_flow. If `authentication_enabled` is `False`, the `SumoClient` object will not initialize an `Auth` object and the user will have to provide an `access_token` parameter with each request.

If a user tries to perform a request without providing `access_token` while `authentication_enabled` is `False`, an exception will be raised.