### PR TITLE
Update pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,9 @@ jobs:
         
       - name: Run pytest
         run: |
-          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
-          echo ${#access_token}
+          az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv
           
-          pytest -q -s --token $access_token tests/test_sumo_thin_client.py
+          #access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
+          #echo ${#access_token}
+          
+          #pytest -q -s --token $access_token tests/test_sumo_thin_client.py


### PR DESCRIPTION
Something is wrong with the output of the `az account get-access-token` command. When passing it to `SumoClient` it is unable to decode it as a jwt. I would like to see the output, but it's probably not a good idea to have an access token in the logs. 

I could delete the run after it's done and invalidate the token? Any thoughts?