### PR TITLE
Update pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,6 @@ jobs:
           client-id: f96c150d-cacf-4257-9cc9-54b2c68ec4ce
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
           subscription-id: 87897772-fb27-495f-ae40-486a2df57baa
-          audience: api://88d2b022-3539-4dda-9e66-853801334a86
           
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3


### PR DESCRIPTION
Removed audience, due to this error:

AADSTS70021: No matching federated identity record found for presented assertion. Assertion Issuer: 'https://token.actions.githubusercontent.com/'. Assertion Subject: 'repo:equinor/sumo-wrapper-python:pull_request'. Assertion Audience: 'api://88d2b022-3539-4dda-9e66-853801334a86'. https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation