### PR TITLE
Encrypt token cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 msal~=1.17.0
+msal-extensions~=1.0.0
 requests~=2.24.0
 pytest~=6.1.1
 PyYAML>=5.4

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -6,8 +6,8 @@ import json
 import logging
 
 from msal_extensions import build_encrypted_persistence
+from msal_extensions.persistence import FilePersistenceWithDataProtection, FilePersistence, PersistenceDecryptionError
 from msal_extensions.token_cache import PersistedTokenCache
-
 from .config import AUTHORITY_HOST_URI
 
 HOME_DIR = os.path.expanduser("~")
@@ -46,6 +46,16 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
+
+        if os.path.exists(token_path):
+            encrypted_persistence = FilePersistenceWithDataProtection(token_path)
+            try:
+                token = encrypted_persistence.load()
+            except PersistenceDecryptionError:
+                token = FilePersistence(token_path).load()
+                encrypted_persistence.save(token)    
+                pass
+            pass            
 
         persistence = build_encrypted_persistence(token_path)
 

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -1,18 +1,20 @@
-import atexit
 import msal
 import os
 import sys
 import json
 import logging
-
-from msal_extensions import build_encrypted_persistence
-from msal_extensions.persistence import FilePersistenceWithDataProtection, FilePersistence, PersistenceDecryptionError
-from msal_extensions.token_cache import PersistedTokenCache
 from .config import AUTHORITY_HOST_URI
+from msal_extensions.persistence import FilePersistence
+from msal_extensions.token_cache import PersistedTokenCache
+if not sys.platform.startswith('linux'):
+    from msal_extensions import build_encrypted_persistence
+    from msal_extensions.persistence import FilePersistenceWithDataProtection,\
+    PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
 logger = logging.getLogger("sumo.wrapper")
+
 
 class NewAuth:
     """Sumo connection
@@ -46,20 +48,31 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
+        
+        # https://github.com/AzureAD/microsoft-authentication-extensions-\
+        # for-python
+        # Encryption not supported on linux servers like rgs, and
+        # neither is common usage from many cluster nodes.
+        # Encryption is supported on Windows and Mac.
 
-        if os.path.exists(token_path):
-            encrypted_persistence = FilePersistenceWithDataProtection(token_path)
-            try:
-                token = encrypted_persistence.load()
-            except PersistenceDecryptionError:
-                token = FilePersistence(token_path).load()
-                encrypted_persistence.save(token)    
-                pass
-            pass            
+        if sys.platform.startswith('linux'):
+            persistence = FilePersistence(token_path)
+            cache = PersistedTokenCache(persistence)
+        else:
+            if os.path.exists(token_path):
+                encrypted_persistence = FilePersistenceWithDataProtection(
+                    token_path)
+                try:
+                    token = encrypted_persistence.load()
+                except PersistenceDecryptionError:
+                    # This code will encrypt an unencrypted existing file 
+                    token = FilePersistence(token_path).load()
+                    encrypted_persistence.save(token)    
+                    pass
+                pass            
 
-        persistence = build_encrypted_persistence(token_path)
-
-        cache = PersistedTokenCache(persistence)
+            persistence = build_encrypted_persistence(token_path)
+            cache = PersistedTokenCache(persistence)
 
         self.msal = msal.PublicClientApplication(
             client_id=client_id,
@@ -131,6 +144,7 @@ class NewAuth:
 
         return result["access_token"]
 
+
 if __name__ == "__main__":
     auth = NewAuth(
         "1826bd7c-582f-4838-880d-5b4da5c3eea2",
@@ -139,4 +153,3 @@ if __name__ == "__main__":
         interactive=True
     )
     print(auth.get_token())
-

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -9,7 +9,7 @@ from msal_extensions.token_cache import PersistedTokenCache
 if not sys.platform.startswith('linux'):
     from msal_extensions import build_encrypted_persistence
     from msal_extensions.persistence import FilePersistenceWithDataProtection,\
-    PersistenceDecryptionError
+        PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
@@ -48,7 +48,7 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
-        
+
         # https://github.com/AzureAD/microsoft-authentication-extensions-\
         # for-python
         # Encryption not supported on linux servers like rgs, and
@@ -65,14 +65,18 @@ class NewAuth:
                 try:
                     token = encrypted_persistence.load()
                 except PersistenceDecryptionError:
-                    # This code will encrypt an unencrypted existing file 
+                    # This code will encrypt an unencrypted existing file
                     token = FilePersistence(token_path).load()
-                    encrypted_persistence.save(token)    
+                    encrypted_persistence.save(token)
                     pass
-                pass            
+                pass
 
             persistence = build_encrypted_persistence(token_path)
             cache = PersistedTokenCache(persistence)
+
+        if not sys.platform.lower().startswith("win"):
+            os.chmod(token_path, 0o600)
+            os.chmod(os.path.dirname(token_path), 0o700)
 
         self.msal = msal.PublicClientApplication(
             client_id=client_id,

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -48,6 +48,7 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
+        self.token_path = token_path
 
         # https://github.com/AzureAD/microsoft-authentication-extensions-\
         # for-python
@@ -73,10 +74,6 @@ class NewAuth:
 
             persistence = build_encrypted_persistence(token_path)
             cache = PersistedTokenCache(persistence)
-
-        if not sys.platform.lower().startswith("win"):
-            os.chmod(token_path, 0o600)
-            os.chmod(os.path.dirname(token_path), 0o700)
 
         self.msal = msal.PublicClientApplication(
             client_id=client_id,
@@ -145,6 +142,9 @@ class NewAuth:
                             "Failed to acquire token by device flow. Err: %s"
                             % json.dumps(result, indent=4)
                         )
+        if not sys.platform.lower().startswith("win"):
+            os.chmod(self.token_path, 0o600)
+            os.chmod(os.path.dirname(self.token_path), 0o700)
 
         return result["access_token"]
 


### PR DESCRIPTION
Use msal-extensions for secure storage of cached tokens on supported platforms (win/mac). 