### PR TITLE
Encrypt token cache3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 msal~=1.17.0
+msal-extensions~=1.0.0
 requests~=2.24.0
 pytest~=6.1.1
 PyYAML>=5.4

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -6,8 +6,8 @@ import json
 import logging
 
 from msal_extensions import build_encrypted_persistence
+from msal_extensions.persistence import FilePersistenceWithDataProtection, FilePersistence, PersistenceDecryptionError
 from msal_extensions.token_cache import PersistedTokenCache
-
 from .config import AUTHORITY_HOST_URI
 
 HOME_DIR = os.path.expanduser("~")
@@ -46,6 +46,16 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
+
+        if os.path.exists(token_path):
+            encrypted_persistence = FilePersistenceWithDataProtection(token_path)
+            try:
+                token = encrypted_persistence.load()
+            except PersistenceDecryptionError:
+                token = FilePersistence(token_path).load()
+                encrypted_persistence.save(token)    
+                pass
+            pass            
 
         persistence = build_encrypted_persistence(token_path)
 

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -46,7 +46,9 @@ class NewAuth:
         self.scope = resource_id + "/.default"
         self.refresh_token = refresh_token
 
-        token_path = os.path.join(HOME_DIR, ".sumo", str(resource_id) + ".token")
+        token_path = os.path.join(
+            HOME_DIR, ".sumo", str(resource_id) + ".token"
+        )
         self.token_path = token_path
 
         # https://github.com/AzureAD/microsoft-authentication-extensions-\
@@ -103,7 +105,9 @@ class NewAuth:
         result = None
 
         if accounts:
-            result = self.msal.acquire_token_silent([self.scope], account=accounts[0])
+            result = self.msal.acquire_token_silent(
+                [self.scope], account=accounts[0]
+            )
 
         if not result:
             if self.refresh_token:

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -10,7 +10,6 @@ from msal_extensions.token_cache import PersistedTokenCache
 
 if not sys.platform.startswith("linux"):
     from msal_extensions import build_encrypted_persistence
-    from msal_extensions.persistence import PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
@@ -61,7 +60,7 @@ class NewAuth:
             persistence = FilePersistence(token_path)
             cache = PersistedTokenCache(persistence)
         else:
-            print("RROWHH")
+            print("ROWH22")
             if os.path.exists(token_path):
                 encrypted_persistence = build_encrypted_persistence(token_path)
                 try:

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -60,7 +60,6 @@ class NewAuth:
             persistence = FilePersistence(token_path)
             cache = PersistedTokenCache(persistence)
         else:
-            print("ROWH22")
             if os.path.exists(token_path):
                 encrypted_persistence = build_encrypted_persistence(token_path)
                 try:

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -1,4 +1,3 @@
-import atexit
 import msal
 import os
 import sys
@@ -9,11 +8,13 @@ from msal_extensions.persistence import FilePersistence
 from msal_extensions.token_cache import PersistedTokenCache
 if not sys.platform.startswith('linux'):
     from msal_extensions import build_encrypted_persistence
-    from msal_extensions.persistence import FilePersistenceWithDataProtection, PersistenceDecryptionError
+    from msal_extensions.persistence import FilePersistenceWithDataProtection,\
+    PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
 logger = logging.getLogger("sumo.wrapper")
+
 
 class NewAuth:
     """Sumo connection
@@ -48,17 +49,19 @@ class NewAuth:
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
         
-        # https://github.com/AzureAD/microsoft-authentication-extensions-for-python
-        # Encryption not supported on linux servers like rgs, and 
+        # https://github.com/AzureAD/microsoft-authentication-extensions-\
+        # for-python
+        # Encryption not supported on linux servers like rgs, and
         # neither is common usage from many cluster nodes.
-        # Encryption is supported on Windows and Mac. 
+        # Encryption is supported on Windows and Mac.
 
         if sys.platform.startswith('linux'):
             persistence = FilePersistence(token_path)
             cache = PersistedTokenCache(persistence)
         else:
             if os.path.exists(token_path):
-                encrypted_persistence = FilePersistenceWithDataProtection(token_path)
+                encrypted_persistence = FilePersistenceWithDataProtection(
+                    token_path)
                 try:
                     token = encrypted_persistence.load()
                 except PersistenceDecryptionError:
@@ -141,6 +144,7 @@ class NewAuth:
 
         return result["access_token"]
 
+
 if __name__ == "__main__":
     auth = NewAuth(
         "1826bd7c-582f-4838-880d-5b4da5c3eea2",
@@ -149,4 +153,3 @@ if __name__ == "__main__":
         interactive=True
     )
     print(auth.get_token())
-

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -4,11 +4,12 @@ import os
 import sys
 import json
 import logging
-
-from msal_extensions import build_encrypted_persistence
-from msal_extensions.persistence import FilePersistenceWithDataProtection, FilePersistence, PersistenceDecryptionError
-from msal_extensions.token_cache import PersistedTokenCache
 from .config import AUTHORITY_HOST_URI
+from msal_extensions.persistence import FilePersistence
+from msal_extensions.token_cache import PersistedTokenCache
+if not sys.platform.startswith('linux'):
+    from msal_extensions import build_encrypted_persistence
+    from msal_extensions.persistence import FilePersistenceWithDataProtection, PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
@@ -46,20 +47,29 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
+        
+        # https://github.com/AzureAD/microsoft-authentication-extensions-for-python
+        # Encryption not supported on linux servers like rgs, and 
+        # neither is common usage from many cluster nodes.
+        # Encryption is supported on Windows and Mac. 
 
-        if os.path.exists(token_path):
-            encrypted_persistence = FilePersistenceWithDataProtection(token_path)
-            try:
-                token = encrypted_persistence.load()
-            except PersistenceDecryptionError:
-                token = FilePersistence(token_path).load()
-                encrypted_persistence.save(token)    
-                pass
-            pass            
+        if sys.platform.startswith('linux'):
+            persistence = FilePersistence(token_path)
+            cache = PersistedTokenCache(persistence)
+        else:
+            if os.path.exists(token_path):
+                encrypted_persistence = FilePersistenceWithDataProtection(token_path)
+                try:
+                    token = encrypted_persistence.load()
+                except PersistenceDecryptionError:
+                    # This code will encrypt an unencrypted existing file 
+                    token = FilePersistence(token_path).load()
+                    encrypted_persistence.save(token)    
+                    pass
+                pass            
 
-        persistence = build_encrypted_persistence(token_path)
-
-        cache = PersistedTokenCache(persistence)
+            persistence = build_encrypted_persistence(token_path)
+            cache = PersistedTokenCache(persistence)
 
         self.msal = msal.PublicClientApplication(
             client_id=client_id,

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -9,7 +9,7 @@ from msal_extensions.token_cache import PersistedTokenCache
 if not sys.platform.startswith('linux'):
     from msal_extensions import build_encrypted_persistence
     from msal_extensions.persistence import FilePersistenceWithDataProtection,\
-    PersistenceDecryptionError
+        PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
@@ -48,7 +48,7 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
-        
+
         # https://github.com/AzureAD/microsoft-authentication-extensions-\
         # for-python
         # Encryption not supported on linux servers like rgs, and
@@ -65,11 +65,11 @@ class NewAuth:
                 try:
                     token = encrypted_persistence.load()
                 except PersistenceDecryptionError:
-                    # This code will encrypt an unencrypted existing file 
+                    # This code will encrypt an unencrypted existing file
                     token = FilePersistence(token_path).load()
-                    encrypted_persistence.save(token)    
+                    encrypted_persistence.save(token)
                     pass
-                pass            
+                pass
 
             persistence = build_encrypted_persistence(token_path)
             cache = PersistedTokenCache(persistence)

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -74,6 +74,10 @@ class NewAuth:
             persistence = build_encrypted_persistence(token_path)
             cache = PersistedTokenCache(persistence)
 
+        if not sys.platform.lower().startswith("win"):
+            os.chmod(token_path, 0o600)
+            os.chmod(os.path.dirname(token_path), 0o700)
+
         self.msal = msal.PublicClientApplication(
             client_id=client_id,
             authority=f"{AUTHORITY_HOST_URI}/{tenant_id}",

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -1,5 +1,6 @@
 import msal
 import os
+import stat
 import sys
 import json
 import logging
@@ -48,6 +49,7 @@ class NewAuth:
         token_path = os.path.join(
             HOME_DIR, ".sumo", str(resource_id) + ".token"
         )
+        self.token_path = token_path
 
         # https://github.com/AzureAD/microsoft-authentication-extensions-\
         # for-python
@@ -144,6 +146,12 @@ class NewAuth:
                             "Failed to acquire token by device flow. Err: %s"
                             % json.dumps(result, indent=4)
                         )
+
+        if sys.platform.startswith('linux'):
+            if stat.filemode(os.stat(self.token_path).st_mode) != "-rw-------":
+                os.chmod(self.token_path, 0o600)
+            if stat.filemode(os.stat(os.path.dirname(self.token_path)).st_mode) != "drwx------":
+                os.chmod(os.path.dirname(self.token_path), 0o700)
 
         return result["access_token"]
 

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -7,7 +7,8 @@ import logging
 from .config import AUTHORITY_HOST_URI
 from msal_extensions.persistence import FilePersistence
 from msal_extensions.token_cache import PersistedTokenCache
-if not sys.platform.startswith('linux'):
+
+if not sys.platform.startswith("linux"):
     from msal_extensions import build_encrypted_persistence
     from msal_extensions.persistence import PersistenceDecryptionError
 
@@ -45,9 +46,7 @@ class NewAuth:
         self.scope = resource_id + "/.default"
         self.refresh_token = refresh_token
 
-        token_path = os.path.join(
-            HOME_DIR, ".sumo", str(resource_id) + ".token"
-        )
+        token_path = os.path.join(HOME_DIR, ".sumo", str(resource_id) + ".token")
         self.token_path = token_path
 
         # https://github.com/AzureAD/microsoft-authentication-extensions-\
@@ -56,10 +55,11 @@ class NewAuth:
         # neither is common usage from many cluster nodes.
         # Encryption is supported on Windows and Mac.
 
-        if sys.platform.startswith('linux'):
+        if sys.platform.startswith("linux"):
             persistence = FilePersistence(token_path)
             cache = PersistedTokenCache(persistence)
         else:
+            print("RROWHH")
             if os.path.exists(token_path):
                 encrypted_persistence = build_encrypted_persistence(token_path)
                 try:
@@ -103,9 +103,7 @@ class NewAuth:
         result = None
 
         if accounts:
-            result = self.msal.acquire_token_silent(
-                [self.scope], account=accounts[0]
-            )
+            result = self.msal.acquire_token_silent([self.scope], account=accounts[0])
 
         if not result:
             if self.refresh_token:
@@ -145,7 +143,7 @@ class NewAuth:
                             % json.dumps(result, indent=4)
                         )
 
-        if sys.platform.startswith('linux'):
+        if sys.platform.startswith("linux"):
             filemode = stat.filemode(os.stat(self.token_path).st_mode)
             if filemode != "-rw-------":
                 os.chmod(self.token_path, 0o600)
@@ -162,6 +160,6 @@ if __name__ == "__main__":
         "1826bd7c-582f-4838-880d-5b4da5c3eea2",
         "88d2b022-3539-4dda-9e66-853801334a86",
         "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
-        interactive=True
+        interactive=True,
     )
     print(auth.get_token())

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -9,8 +9,7 @@ from msal_extensions.persistence import FilePersistence
 from msal_extensions.token_cache import PersistedTokenCache
 if not sys.platform.startswith('linux'):
     from msal_extensions import build_encrypted_persistence
-    from msal_extensions.persistence import PersistenceDecryptionError, \
-        PersistenceNotFound
+    from msal_extensions.persistence import PersistenceDecryptionError
 
 HOME_DIR = os.path.expanduser("~")
 
@@ -65,7 +64,7 @@ class NewAuth:
                 token_path)
             try:
                 token = encrypted_persistence.load()
-            except:
+            except PersistenceDecryptionError:
                 # This code will encrypt an unencrypted existing file
                 if os.path.exists(token_path):
                     token = FilePersistence(token_path).load()
@@ -148,9 +147,12 @@ class NewAuth:
                         )
 
         if sys.platform.startswith('linux'):
-            if stat.filemode(os.stat(self.token_path).st_mode) != "-rw-------":
+            filemode = stat.filemode(os.stat(self.token_path).st_mode)
+            if filemode != "-rw-------":
                 os.chmod(self.token_path, 0o600)
-            if stat.filemode(os.stat(os.path.dirname(self.token_path)).st_mode) != "drwx------":
+            folder = os.path.dirname(self.token_path)
+            foldermode = stat.filemode(os.stat(folder).st_mode)
+            if foldermode != "drwx------":
                 os.chmod(os.path.dirname(self.token_path), 0o700)
 
         return result["access_token"]

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -77,10 +77,6 @@ class NewAuth:
             persistence = build_encrypted_persistence(token_path)
             cache = PersistedTokenCache(persistence)
 
-        if sys.platform.startswith('linux'):
-            os.chmod(token_path, 0o600)
-            os.chmod(os.path.dirname(token_path), 0o700)
-
         self.msal = msal.PublicClientApplication(
             client_id=client_id,
             authority=f"{AUTHORITY_HOST_URI}/{tenant_id}",

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -66,7 +66,7 @@ class NewAuth:
                 encrypted_persistence = build_encrypted_persistence(token_path)
                 try:
                     token = encrypted_persistence.load()
-                except PersistenceDecryptionError:
+                except Exception:
                     # This code will encrypt an unencrypted existing file
                     token = FilePersistence(token_path).load()
                     with open(token_path, "w") as f:

--- a/src/sumo/wrapper/_new_auth.py
+++ b/src/sumo/wrapper/_new_auth.py
@@ -60,13 +60,12 @@ class NewAuth:
             persistence = FilePersistence(token_path)
             cache = PersistedTokenCache(persistence)
         else:
-            encrypted_persistence = build_encrypted_persistence(
-                token_path)
-            try:
-                token = encrypted_persistence.load()
-            except PersistenceDecryptionError:
-                # This code will encrypt an unencrypted existing file
-                if os.path.exists(token_path):
+            if os.path.exists(token_path):
+                encrypted_persistence = build_encrypted_persistence(token_path)
+                try:
+                    token = encrypted_persistence.load()
+                except PersistenceDecryptionError:
+                    # This code will encrypt an unencrypted existing file
                     token = FilePersistence(token_path).load()
                     with open(token_path, "w") as f:
                         f.truncate()

--- a/tests/test_call_sumo_api.py
+++ b/tests/test_call_sumo_api.py
@@ -109,7 +109,8 @@ def test_upload_search_delete_ensemble_child():
     surface_id = response_surface.json().get("objectid")
 
     # Upload BLOB
-    response_blob = _upload_blob(C=C, blob=B, object_id=surface_id)
+    url = response_surface.json().get("blob_url")
+    response_blob = _upload_blob(C=C, blob=B, object_id=surface_id, url=url)
     assert 200 <= response_blob.status_code <= 202
 
     sleep(4)


### PR DESCRIPTION
Use msal-extensions for secure storage of cached tokens on supported platforms (win/mac). Reduce token file and folder perms on rgs/linux.