### PR TITLE
bump required py version to 3.6

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,14 @@
 import os
 
+
 def pytest_addoption(parser):
     parser.addoption("--token", action="store", default="")
+
 
 def pytest_generate_tests(metafunc):
     # token = metafunc.config.option.token
     token = os.environ.get("ACCESS_TOKEN")
-    token = token if len(token) > 0 else None
+    token = token if token and len(token) > 0 else None
 
     if "token" in metafunc.fixturenames:
         metafunc.parametrize("token", [token])

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     use_scm_version={"write_to": "src/sumo/wrapper/version.py"},
     author="Equinor ASA",
     install_requires=REQUIREMENTS,
-    python_requires=">=3.4",
+    python_requires=">=3.6",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -6,7 +6,7 @@ from time import sleep
 import sys
 import os
 
-sys.path.append(os.path.abspath(os.path.join('src')))
+sys.path.append(os.path.abspath(os.path.join("src")))
 
 from sumo.wrapper import SumoClient
 
@@ -56,8 +56,7 @@ def _upload_child_level_json(C, parent_id, json):
     response = C.api.post(f"/objects('{parent_id}')", json=json)
 
     if not 200 <= response.status_code < 202:
-        raise Exception(
-            f"Response: {response.status_code}, Text: {response.text}")
+        raise Exception(f"Response: {response.status_code}, Text: {response.text}")
     return response
 
 
@@ -76,6 +75,7 @@ class ValueKeeper:
 """ TESTS """
 
 import uuid
+
 
 def test_upload_search_delete_ensemble_child(token):
     """
@@ -101,7 +101,7 @@ def test_upload_search_delete_ensemble_child(token):
     assert isinstance(response_case.json(), dict)
 
     case_id = response_case.json().get("objectid")
-    assert(case_id == case_uuid)
+    assert case_id == case_uuid
 
     sleep(5)
 
@@ -111,8 +111,7 @@ def test_upload_search_delete_ensemble_child(token):
 
     fmu_surface_metadata["fmu"]["case"]["uuid"] = case_uuid
 
-    fmu_surface_id = fmu_surface_metadata.get(
-        "fmu").get("realization").get("id")
+    fmu_surface_id = fmu_surface_metadata.get("fmu").get("realization").get("id")
     response_surface = _upload_child_level_json(
         C=C, parent_id=case_id, json=fmu_surface_metadata
     )


### PR DESCRIPTION
Since we use type hinting, it will not work for Python < `3.5`. In reality, we should not require it to work for Python < `3.8`, but setting `3.6` since it is still in use here and there.