### PR TITLE
Support query params in post method

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,6 @@ exclude =
     _call_azure_api.py
     _call_sumo_api.py
     _auth.py
+    test_call_sumo_api.py
+    test_sumo_thin_client.py
+    setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ requires = [
   "setuptools_scm>=3.2.0",
   "wheel"
 ]
+
+[tool.black]
+line-length = 80

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -204,7 +204,11 @@ class SumoClient:
         return response.json()
 
     def post(
-        self, path: str, blob: bytes = None, json: dict = None
+        self,
+        path: str,
+        blob: bytes = None,
+        json: dict = None,
+        params: dict = None,
     ) -> requests.Response:
         """Performs a POST-request to the Sumo API.
 
@@ -252,20 +256,26 @@ class SumoClient:
             raise ValueError("Both blob and json given to post.")
 
         content_type = (
-            "application/json"
-            if json is not None
-            else "application/octet-stream"
+            "application/octet-stream" if blob else "application/json"
         )
+        content_length = 0
+
+        if blob or json:
+            content_length = len(json) if json else len(blob)
 
         headers = {
             "Content-Type": content_type,
             "authorization": f"Bearer {token}",
-            "Content-Length": str(len(json) if json else len(blob)),
+            "Content-Length": str(content_length),
         }
 
         try:
             response = requests.post(
-                f"{self.base_url}{path}", data=blob, json=json, headers=headers
+                f"{self.base_url}{path}",
+                data=blob,
+                json=json,
+                headers=headers,
+                params=params,
             )
         except requests.exceptions.ProxyError as err:
             raise_request_error_exception(503, err)


### PR DESCRIPTION
I need to call the `POST/pit` endpoint in sumo-core, which takes a `keep-alive` query parameter, but `SumoClient.post` does not support query parameters. 

I added a `params` parameter to `SumoClien.post` so I can do this:

```python
sumo = SumoClient()

sumo.post("/pit", params={"keep-alive": "10m"})
```

This approach is different from the one used in `SumoClient.get` which takes query parameters as kwargs and prefixes them with `$`. Since it's not possible to use certain characters like `$` and `-` in python parameter names I think we at some point should use the approach above for `SumoClient.get` too, instead of kwargs.