### PR TITLE
allow SumoAggregationClient to fail create

### DIFF
--- a/src/sumo/wrapper/_sumo_aggregation_client.py
+++ b/src/sumo/wrapper/_sumo_aggregation_client.py
@@ -1,5 +1,7 @@
 import logging
+import time
 
+import jwt
 import requests
 
 from ._new_auth import NewAuth
@@ -13,6 +15,7 @@ class SumoAggregationClient:
     def __init__(
         self,
         env: str,
+        token: str = None,
         interactive: bool = False,
         verbosity: str = "CRITICAL",
     ):
@@ -30,13 +33,26 @@ class SumoAggregationClient:
         if env not in AGG_APP_REGISTRATION:
             raise ValueError(f"Invalid environment: {env}")
 
-        self.auth = NewAuth(
-            client_id=AGG_APP_REGISTRATION[env]["CLIENT_ID"],
-            resource_id=AGG_APP_REGISTRATION[env]["RESOURCE_ID"],
-            tenant_id=TENANT_ID,
-            interactive=interactive,
-            verbosity=verbosity,
-        )
+        self.access_token = None
+        self.access_token_expires = None
+        if token:
+            logger.debug("Token provided")
+            payload = self.__decode_token(token)
+
+            if payload:
+                logger.debug(f"Token decoded as JWT, payload: {payload}")
+                self.access_token = token
+                self.access_token_expires = payload["exp"]
+            else:
+                logger.debug("Unable to decode token as JWT")
+        else:
+            self.auth = NewAuth(
+                client_id=AGG_APP_REGISTRATION[env]["CLIENT_ID"],
+                resource_id=AGG_APP_REGISTRATION[env]["RESOURCE_ID"],
+                tenant_id=TENANT_ID,
+                interactive=interactive,
+                verbosity=verbosity,
+            )
 
         if env == "localhost":
             self.base_url = (
@@ -49,6 +65,43 @@ class SumoAggregationClient:
                 + ".radix.equinor.com"
             )
 
+    def __decode_token(self, token: str) -> dict:
+        """
+        Decodes a Json Web Token, returns the payload as a dictionary.
+
+        Args:
+            token: Token to decode
+
+        Returns:
+            Decoded Json Web Token (None if token can't be decoded)
+        """
+
+        try:
+            payload = jwt.decode(token, options={"verify_signature": False})
+            return payload
+        except jwt.InvalidTokenError:
+            return None
+
+    def _retrieve_token(self) -> str:
+        """Retrieve a token for the Sumo API.
+
+        Returns:
+            A Json Web Token
+        """
+
+        if self.access_token:
+            logger.debug(
+                "User provided access_token exists, " "checking expire time"
+            )
+            if self.access_token_expires <= int(time.time()):
+                raise ValueError("Access_token has expired")
+            else:
+                logger.debug("Returning user provided access token")
+                return self.access_token
+
+        logger.debug("No user provided token exists, retrieving access token")
+        return self.auth.get_token()
+
     def get_aggregate(self, json: dict):
         """
         Performs a POST-request to Sumo Aggregation API /fastaggregation.
@@ -60,7 +113,7 @@ class SumoAggregationClient:
         Returns:
             Sumo aggregate response object
         """
-        token = self.auth.get_token()
+        token = self._retrieve_token()
 
         headers = {
             "Content-Type": "application/json",

--- a/src/sumo/wrapper/_sumo_aggregation_client.py
+++ b/src/sumo/wrapper/_sumo_aggregation_client.py
@@ -1,12 +1,12 @@
 import logging
 import time
 
-import jwt
 import requests
 
 from ._new_auth import NewAuth
 from ._request_error import raise_request_error_exception
 from .config import AGG_APP_REGISTRATION, TENANT_ID
+from .utils import decode_jwt_token
 
 logger = logging.getLogger("sumo.wrapper")
 
@@ -37,7 +37,7 @@ class SumoAggregationClient:
         self.access_token_expires = None
         if token:
             logger.debug("Token provided")
-            payload = self.__decode_token(token)
+            payload = decode_jwt_token(token)
 
             if payload:
                 logger.debug(f"Token decoded as JWT, payload: {payload}")
@@ -65,25 +65,8 @@ class SumoAggregationClient:
                 + ".radix.equinor.com"
             )
 
-    def __decode_token(self, token: str) -> dict:
-        """
-        Decodes a Json Web Token, returns the payload as a dictionary.
-
-        Args:
-            token: Token to decode
-
-        Returns:
-            Decoded Json Web Token (None if token can't be decoded)
-        """
-
-        try:
-            payload = jwt.decode(token, options={"verify_signature": False})
-            return payload
-        except jwt.InvalidTokenError:
-            return None
-
     def _retrieve_token(self) -> str:
-        """Retrieve a token for the Sumo API.
+        """Retrieve a token for the Sumo Surface Aggregation service.
 
         Returns:
             A Json Web Token

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -19,6 +19,8 @@ class SumoClient:
         self,
         env: str,
         token: str = None,
+        aggregation_token: str = None,
+        enable_aggregation: bool = True,
         interactive: bool = False,
         verbosity: str = "CRITICAL",
     ):
@@ -71,9 +73,14 @@ class SumoClient:
         else:
             self.base_url = f"https://main-sumo-{env}.radix.equinor.com/api/v1"
 
-        self.agg_client = SumoAggregationClient(
-            env=env, interactive=interactive, verbosity=verbosity
-        )
+        if enable_aggregation:
+            self.aggregation_enabled = enable_aggregation
+            self.agg_client = SumoAggregationClient(
+                env=env,
+                token=aggregation_token,
+                interactive=interactive,
+                verbosity=verbosity,
+            )
 
     def authenticate(self) -> str:
         """Authenticate to Sumo.
@@ -377,4 +384,6 @@ class SumoClient:
         Returns:
             Sumo aggregate response object
         """
-        return self.agg_client.get_aggregate(json)
+        if self.aggregation_enabled:
+            return self.agg_client.get_aggregate(json)
+        logger.debug("Aggregation not enabled.")

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -1,13 +1,14 @@
-import requests
-import jwt
-import time
 import logging
+import time
 
-from .config import APP_REGISTRATION, TENANT_ID
+import requests
+
+from ._blob_client import BlobClient
 from ._new_auth import NewAuth
 from ._request_error import raise_request_error_exception
-from ._blob_client import BlobClient
 from ._sumo_aggregation_client import SumoAggregationClient
+from .config import APP_REGISTRATION, TENANT_ID
+from .utils import decode_jwt_token
 
 logger = logging.getLogger("sumo.wrapper")
 
@@ -45,7 +46,7 @@ class SumoClient:
 
         if token:
             logger.debug("Token provided")
-            payload = self.__decode_token(token)
+            payload = decode_jwt_token(token)
 
             if payload:
                 logger.debug(f"Token decoded as JWT, payload: {payload}")
@@ -116,23 +117,6 @@ class SumoClient:
         """
 
         return self._blob_client
-
-    def __decode_token(self, token: str) -> dict:
-        """
-        Decodes a Json Web Token, returns the payload as a dictionary.
-
-        Args:
-            token: Token to decode
-
-        Returns:
-            Decoded Json Web Token (None if token can't be decoded)
-        """
-
-        try:
-            payload = jwt.decode(token, options={"verify_signature": False})
-            return payload
-        except jwt.InvalidTokenError:
-            return None
 
     def _retrieve_token(self) -> str:
         """Retrieve a token for the Sumo API.

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -20,7 +20,6 @@ class SumoClient:
         env: str,
         token: str = None,
         aggregation_token: str = None,
-        enable_aggregation: bool = True,
         interactive: bool = False,
         verbosity: str = "CRITICAL",
     ):
@@ -73,13 +72,19 @@ class SumoClient:
         else:
             self.base_url = f"https://main-sumo-{env}.radix.equinor.com/api/v1"
 
-        if enable_aggregation:
-            self.aggregation_enabled = enable_aggregation
+        self.aggregation_enabled = False
+        try:
             self.agg_client = SumoAggregationClient(
                 env=env,
                 token=aggregation_token,
                 interactive=interactive,
                 verbosity=verbosity,
+            )
+            self.aggregation_enabled = True
+        except Exception as e:
+            logger.error(
+                "Failed setting up Sumo aggregation client."
+                + f"Aggregation methods will not work: {e}"
             )
 
     def authenticate(self) -> str:

--- a/src/sumo/wrapper/utils.py
+++ b/src/sumo/wrapper/utils.py
@@ -1,0 +1,19 @@
+import jwt
+
+
+def decode_jwt_token(self, token: str) -> dict:
+    """
+    Decodes a Json Web Token, returns the payload as a dictionary.
+
+    Args:
+        token: Token to decode
+
+    Returns:
+        Decoded Json Web Token (None if token can't be decoded)
+    """
+
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+        return payload
+    except jwt.InvalidTokenError:
+        return None

--- a/src/sumo/wrapper/utils.py
+++ b/src/sumo/wrapper/utils.py
@@ -1,7 +1,7 @@
 import jwt
 
 
-def decode_jwt_token(self, token: str) -> dict:
+def decode_jwt_token(token: str) -> dict:
     """
     Decodes a Json Web Token, returns the payload as a dictionary.
 


### PR DESCRIPTION
* add option to pass `agg_token` when creating SumoClient: `agg_token` works the same for `SumoAggregationClient` as token for `SumoClient`
* if creating `SumoAggregationClient` fails: log warning that aggregation will not be possible and carry on. 
> `SumoAggregationClient` would fail creation in surface aggregation upload job (in Radix) due to no token on disk and not possible to do interactive login. 

Note: user will have to do a second device code flow towards the aggregation service if no `agg_token` is provided or cached