### PR TITLE
Post timeout none

### DIFF
--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -512,6 +512,7 @@ class SumoClient:
                     json=json,
                     headers=headers,
                     params=params,
+                    timeout=None,
                 )
         except httpx.ProxyError as err:
             raise_request_error_exception(503, err)

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -283,6 +283,7 @@ class SumoClient:
                 json=json,
                 headers=headers,
                 params=params,
+                timeout=None,
             )
         except httpx.ProxyError as err:
             raise_request_error_exception(503, err)


### PR DESCRIPTION
Default for previous library `requests` was none.