### PR TITLE
Add raise_for_status_async decorator + follow_redirect

### DIFF
--- a/src/sumo/wrapper/_blob_client.py
+++ b/src/sumo/wrapper/_blob_client.py
@@ -1,6 +1,6 @@
 import httpx
 
-from ._decorators import raise_for_status, http_retry
+from ._decorators import raise_for_status, http_retry, raise_for_status_async
 
 
 class BlobClient:
@@ -25,7 +25,7 @@ class BlobClient:
 
         return response
 
-    @raise_for_status
+    @raise_for_status_async
     @http_retry
     async def upload_blob_async(self, blob: bytes, url: str):
         """Upload a blob async.

--- a/src/sumo/wrapper/_decorators.py
+++ b/src/sumo/wrapper/_decorators.py
@@ -14,6 +14,18 @@ def raise_for_status(func):
     return wrapper
 
 
+def raise_for_status_async(func):
+    async def wrapper(*args, **kwargs):
+        # FIXME: in newer versions of httpx, raise_for_status() is chainable,
+        # so we could simply write
+        # return func(*args, **kwargs).raise_for_status()
+        response = await func(*args, **kwargs)
+        # response.raise_for_status()
+        return response
+
+    return wrapper
+
+
 def http_unpack(func):
     def wrapper(*args, **kwargs):
         response = func(*args, **kwargs)

--- a/src/sumo/wrapper/_decorators.py
+++ b/src/sumo/wrapper/_decorators.py
@@ -20,7 +20,7 @@ def raise_for_status_async(func):
         # so we could simply write
         # return func(*args, **kwargs).raise_for_status()
         response = await func(*args, **kwargs)
-        # response.raise_for_status()
+        response.raise_for_status()
         return response
 
     return wrapper

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -9,7 +9,7 @@ from ._logging import LogHandlerSumo
 from ._auth_provider import get_auth_provider
 from .config import APP_REGISTRATION, TENANT_ID, AUTHORITY_HOST_URI
 
-from ._decorators import raise_for_status, http_retry
+from ._decorators import raise_for_status, http_retry, raise_for_status_async
 
 logger = logging.getLogger("sumo.wrapper")
 
@@ -328,7 +328,7 @@ class SumoClient:
         logger.addHandler(handler)
         return logger
 
-    @raise_for_status
+    @raise_for_status_async
     @http_retry
     async def get_async(self, path: str, params: dict = None):
         """Performs an async GET-request to the Sumo API.
@@ -364,7 +364,7 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.get(
                 f"{self.base_url}{path}",
                 params=params,
@@ -374,7 +374,7 @@ class SumoClient:
 
         return response
 
-    @raise_for_status
+    @raise_for_status_async
     @http_retry
     async def post_async(
         self,
@@ -450,7 +450,7 @@ class SumoClient:
 
         return response
 
-    @raise_for_status
+    @raise_for_status_async
     @http_retry
     async def put_async(
         self, path: str, blob: bytes = None, json: dict = None
@@ -496,7 +496,7 @@ class SumoClient:
 
         return response
 
-    @raise_for_status
+    @raise_for_status_async
     @http_retry
     async def delete_async(self, path: str, params: dict = None) -> dict:
         """Performs an async DELETE-request to the Sumo API.


### PR DESCRIPTION
Added an async version of `raise_for_status` to the async functions.

When attempting to download a blob with `SumoClient.get_async("/objects('{object_ud}')/blob")`, `response.raise_for_status` raises an exception for the `302 Found` status code caused by the redirect. Adding `follow_redirects=True` to the `Httpx.AsyncClient` solved this.