### PR TITLE
Change auth provider precedence

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -211,6 +211,18 @@ def get_auth_provider(
     access_token=None,
     refresh_token=None,
 ):
+    if refresh_token:
+        return AuthProviderRefreshToken(
+            refresh_token, client_id, authority, resource_id
+        )
+    # ELSE
+    if access_token:
+        return AuthProviderAccessToken(access_token)
+    # ELSE
+    if interactive:
+        return AuthProviderInteractive(client_id, authority, resource_id)
+
+    # ELSE
     if all(
         [
             os.getenv(x)
@@ -223,16 +235,6 @@ def get_auth_provider(
         ]
     ):
         return AuthProviderManaged(resource_id)
-    # ELSE
-    if refresh_token:
-        return AuthProviderRefreshToken(
-            refresh_token, client_id, authority, resource_id
-        )
-    # ELSE
-    if access_token:
-        return AuthProviderAccessToken(access_token)
-    # ELSE
-    if interactive:
-        return AuthProviderInteractive(client_id, authority, resource_id)
+
     # ELSE
     return AuthProviderDeviceCode(client_id, authority, resource_id)


### PR DESCRIPTION
I experienced some issues in the aggregation service with the new auth provider logic. I'm constructing a `SumoClient` with a user access token to make requests on behalf of the user, but since the `AZURE_*` environment variables are present it ends up using the managed identity.