### PR TITLE
make it possible to influence the retry strategy

### DIFF
--- a/src/sumo/wrapper/__init__.py
+++ b/src/sumo/wrapper/__init__.py
@@ -1,4 +1,5 @@
 from .sumo_client import SumoClient
+from ._retry_strategy import RetryStrategy
 
 try:
     from .version import version
@@ -7,4 +8,4 @@ try:
 except ImportError:
     __version__ = "0.0.0"
 
-__all__ = ["SumoClient"]
+__all__ = ["SumoClient", "RetryStrategy"]

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -164,13 +164,15 @@ class AuthProviderInteractive(AuthProvider):
             )
             if "error" in result:
                 print(
-                    "\n\n \033[31m Error during Equinor Azure login for Sumo access: \033[0m"
+                    "\n\n \033[31m Error during Equinor Azure login "
+                    "for Sumo access: \033[0m"
                 )
                 print("Err: ", json.dumps(result, indent=4))
                 return
-        except:
+        except Exception:
             print(
-                "\n\n \033[31m Failed Equinor Azure login for Sumo access, one possible reason is timeout \033[0m"
+                "\n\n \033[31m Failed Equinor Azure login for Sumo access, "
+                "one possible reason is timeout \033[0m"
             )
             return
 

--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -1,0 +1,52 @@
+import tenacity as tn
+import httpx
+
+
+def _log_retry_elapsed(retry_state):
+    # logger.log(logging.INFO, f"Attempts: {retry_state.attempt_number}; Elapsed: {retry_state.seconds_since_start}")
+    print(
+        f"Attempts: {retry_state.attempt_number}; "
+        f"Elapsed: {retry_state.seconds_since_start}"
+    )
+    return
+
+
+# Define the conditions for retrying based on exception types
+def _is_retryable_exception(exception):
+    return isinstance(exception, (httpx.TimeoutException, httpx.ConnectError))
+
+
+# Define the conditions for retrying based on HTTP status codes
+def _is_retryable_status_code(response):
+    return response.status_code in [502, 503, 504]
+
+
+def _return_last_value(retry_state):
+    return retry_state.outcome.result()
+
+
+class RetryStrategy:
+    def __init__(self, stop_after=6, multiplier=0.5, exp_base=2):
+        self._stop_after = stop_after
+        self._multiplier = multiplier
+        self._exp_base = exp_base
+        return
+
+    def make_retryer(self):
+        return tn.Retrying(
+            stop=tn.stop_after_attempt(self._stop_after),
+            retry=(
+                tn.retry_if_exception(_is_retryable_exception)
+                | tn.retry_if_result(_is_retryable_status_code)
+            ),
+            wait=(
+                tn.wait_exponential(
+                    multiplier=self._multiplier, exp_base=self._exp_base
+                )
+                + tn.wait_random_exponential(
+                    multiplier=self._multiplier, exp_base=self._exp_base
+                )
+            ),
+            retry_error_callback=_return_last_value,
+            before_sleep=_log_retry_elapsed,
+        )

--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -3,7 +3,11 @@ import httpx
 
 
 def _log_retry_elapsed(retry_state):
-    # logger.log(logging.INFO, f"Attempts: {retry_state.attempt_number}; Elapsed: {retry_state.seconds_since_start}")
+    # logger.log(
+    #     logging.INFO,
+    #     f"Attempts: {retry_state.attempt_number}; "
+    #     f"Elapsed: {retry_state.seconds_since_start}",
+    # )
     print(
         f"Attempts: {retry_state.attempt_number}; "
         f"Elapsed: {retry_state.seconds_since_start}"

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -10,20 +10,11 @@ from ._auth_provider import get_auth_provider
 from .config import APP_REGISTRATION, TENANT_ID, AUTHORITY_HOST_URI
 
 from ._decorators import (
-    is_retryable_exception,
-    is_retryable_status_code,
     raise_for_status,
     raise_for_status_async,
-    return_last_value,
 )
-from tenacity import (
-    retry,
-    retry_if_exception,
-    retry_if_result,
-    wait_exponential,
-    wait_random_exponential,
-    stop_after_attempt,
-)
+
+from ._retry_strategy import RetryStrategy
 
 logger = logging.getLogger("sumo.wrapper")
 
@@ -39,6 +30,7 @@ class SumoClient:
         token: str = None,
         interactive: bool = False,
         verbosity: str = "CRITICAL",
+        retry_strategy=RetryStrategy(),
     ):
         """Initialize a new Sumo object
 
@@ -55,7 +47,8 @@ class SumoClient:
         if env not in APP_REGISTRATION:
             raise ValueError(f"Invalid environment: {env}")
 
-        self._blob_client = BlobClient()
+        self._retry_strategy = retry_strategy
+        self._blob_client = BlobClient(retry_strategy)
 
         access_token = None
         refresh_token = None
@@ -123,17 +116,6 @@ class SumoClient:
         return self._blob_client
 
     @raise_for_status
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
     def get(self, path: str, params: dict = None) -> dict:
         """Performs a GET-request to the Sumo API.
 
@@ -169,28 +151,19 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        response = httpx.get(
-            f"{self.base_url}{path}",
-            params=params,
-            headers=headers,
-            follow_redirects=True,
-            timeout=DEFAULT_TIMEOUT,
-        )
+        def _get():
+            return httpx.get(
+                f"{self.base_url}{path}",
+                params=params,
+                headers=headers,
+                follow_redirects=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
 
-    @raise_for_status
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
+        return retryer(_get)
+
     def post(
         self,
         path: str,
@@ -252,28 +225,21 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        response = httpx.post(
-            f"{self.base_url}{path}",
-            content=blob,
-            json=json,
-            headers=headers,
-            params=params,
-            timeout=DEFAULT_TIMEOUT,
-        )
-        return response
+        def _post():
+            return httpx.post(
+                f"{self.base_url}{path}",
+                content=blob,
+                json=json,
+                headers=headers,
+                params=params,
+                timeout=DEFAULT_TIMEOUT,
+            )
+
+        retryer = self._retry_strategy.make_retryer()
+
+        return retryer(_post)
 
     @raise_for_status
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
     def put(
         self, path: str, blob: bytes = None, json: dict = None
     ) -> httpx.Response:
@@ -307,28 +273,19 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        response = httpx.put(
-            f"{self.base_url}{path}",
-            content=blob,
-            json=json,
-            headers=headers,
-            timeout=DEFAULT_TIMEOUT,
-        )
+        def _put():
+            return httpx.put(
+                f"{self.base_url}{path}",
+                content=blob,
+                json=json,
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT,
+            )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
 
-    @raise_for_status
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
+        return retryer(_put)
+
     def delete(self, path: str, params: dict = None) -> dict:
         """Performs a DELETE-request to the Sumo API.
 
@@ -355,14 +312,17 @@ class SumoClient:
             "Authorization": f"Bearer {token}",
         }
 
-        response = httpx.delete(
-            f"{self.base_url}{path}",
-            headers=headers,
-            params=params,
-            timeout=DEFAULT_TIMEOUT,
-        )
+        def _delete():
+            return httpx.delete(
+                f"{self.base_url}{path}",
+                headers=headers,
+                params=params,
+                timeout=DEFAULT_TIMEOUT,
+            )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
+
+        return retryer(_delete)
 
     def getLogger(self, name):
         """Gets a logger object that sends log objects into the message_log
@@ -383,17 +343,6 @@ class SumoClient:
         return logger
 
     @raise_for_status_async
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
     async def get_async(self, path: str, params: dict = None):
         """Performs an async GET-request to the Sumo API.
 
@@ -428,28 +377,20 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            response = await client.get(
-                f"{self.base_url}{path}",
-                params=params,
-                headers=headers,
-                timeout=DEFAULT_TIMEOUT,
-            )
+        async def _get():
+            async with httpx.AsyncClient(follow_redirects=True) as client:
+                return await client.get(
+                    f"{self.base_url}{path}",
+                    params=params,
+                    headers=headers,
+                    timeout=DEFAULT_TIMEOUT,
+                )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
+
+        return await retryer(_get)
 
     @raise_for_status_async
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
     async def post_async(
         self,
         path: str,
@@ -512,30 +453,22 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                url=f"{self.base_url}{path}",
-                content=blob,
-                json=json,
-                headers=headers,
-                params=params,
-                timeout=DEFAULT_TIMEOUT,
-            )
+        async def _post():
+            async with httpx.AsyncClient() as client:
+                return await client.post(
+                    url=f"{self.base_url}{path}",
+                    content=blob,
+                    json=json,
+                    headers=headers,
+                    params=params,
+                    timeout=DEFAULT_TIMEOUT,
+                )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
+
+        return await retryer(_post)
 
     @raise_for_status_async
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
     async def put_async(
         self, path: str, blob: bytes = None, json: dict = None
     ) -> httpx.Response:
@@ -569,29 +502,21 @@ class SumoClient:
             "authorization": f"Bearer {token}",
         }
 
-        async with httpx.AsyncClient() as client:
-            response = await client.put(
-                url=f"{self.base_url}{path}",
-                content=blob,
-                json=json,
-                headers=headers,
-                timeout=DEFAULT_TIMEOUT,
-            )
+        async def _put():
+            async with httpx.AsyncClient() as client:
+                return await client.put(
+                    url=f"{self.base_url}{path}",
+                    content=blob,
+                    json=json,
+                    headers=headers,
+                    timeout=DEFAULT_TIMEOUT,
+                )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
+
+        return await retryer(_put)
 
     @raise_for_status_async
-    @retry(
-        stop=stop_after_attempt(6),
-        retry=(
-            retry_if_exception(is_retryable_exception)
-            | retry_if_result(is_retryable_status_code)
-        ),
-        wait=wait_exponential(multiplier=0.5)
-        + wait_random_exponential(multiplier=0.5),
-        reraise=True,
-        retry_error_callback=return_last_value,
-    )
     async def delete_async(self, path: str, params: dict = None) -> dict:
         """Performs an async DELETE-request to the Sumo API.
 
@@ -618,12 +543,15 @@ class SumoClient:
             "Authorization": f"Bearer {token}",
         }
 
-        async with httpx.AsyncClient() as client:
-            response = await client.delete(
-                url=f"{self.base_url}{path}",
-                headers=headers,
-                params=params,
-                timeout=DEFAULT_TIMEOUT,
-            )
+        async def _delete():
+            async with httpx.AsyncClient() as client:
+                return await client.delete(
+                    url=f"{self.base_url}{path}",
+                    headers=headers,
+                    params=params,
+                    timeout=DEFAULT_TIMEOUT,
+                )
 
-        return response
+        retryer = self._retry_strategy.make_retryer()
+
+        return await retryer(_delete)

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -164,6 +164,7 @@ class SumoClient:
 
         return retryer(_get)
 
+    @raise_for_status
     def post(
         self,
         path: str,
@@ -286,6 +287,7 @@ class SumoClient:
 
         return retryer(_put)
 
+    @raise_for_status
     def delete(self, path: str, params: dict = None) -> dict:
         """Performs a DELETE-request to the Sumo API.
 

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -226,7 +226,7 @@ def test_upload_duplicate_ensemble(token):
     result = _delete_object(C=C, object_id=case_id1)
     assert result == "Accepted"
 
-    sleep(50)
+    sleep(61)
 
     # Search for ensemble
     with pytest.raises(Exception):

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -226,6 +226,12 @@ def test_upload_duplicate_ensemble(token):
     result = _delete_object(C=C, object_id=case_id1)
     assert result == "Accepted"
 
+    # Ugly: sumo-core has a cache for case objects, which has a
+    # time-to-live of 60 seconds. If there are multiple replicas
+    # running, we might get the situation where we have just deleted
+    # the case via one replica, then ask for the object from another
+    # replica which still has it ins cache. Thus, the magic value 61,
+    # below.
     sleep(61)
 
     # Search for ensemble


### PR DESCRIPTION
With this change, it is possible to pass a `RetryStrategy` object to the `SumoClient`. This allows us to specify values for `stop_after` (maximum number of tries), `exp_base` (the factor by which the retry sleep delay is increased for each retry) and `multiplier`(the initial retry sleep delay).

 