### PR TITLE
add license classifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ name = "sumo-wrapper-python"
 description = "Python wrapper for the Sumo API"
 license = { file = "LICENSE" }
 readme = { file = "README.md", content-type = "text/markdown" }
-classifiers = ["Programming Language :: Python"]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+]
 authors = [{ name = "Equinor" }]
 requires-python = ">=3.8"
 dynamic = ["version"]


### PR DESCRIPTION
[Recommended practice to use the classifier when using standard licenses.](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)