### PR TITLE
Implement retries for authorization code

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -139,6 +139,19 @@ def get_token_cache(resource_id, suffix):
     return cache
 
 
+@tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
+          stop=tn.stop_after_attempt(6),
+          wait=(
+                tn.wait_exponential(
+                    multiplier=0.5, exp_base=2
+                )
+                + tn.wait_random_exponential(
+                    multiplier=0.5, exp_base=2
+                )
+            ),
+            retry_error_callback=_return_last_value,
+            before_sleep=_log_retry_info,
+          )
 def protect_token_cache(resource_id, suffix):
     token_path = get_token_path(resource_id, suffix)
 

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -14,8 +14,6 @@ from msal_extensions.persistence import FilePersistence
 from msal_extensions.token_cache import PersistedTokenCache
 import errno
 
-# FIXME: remove
-import random
 
 if not sys.platform.startswith("linux"):
     from msal_extensions import build_encrypted_persistence
@@ -108,11 +106,6 @@ def get_token_cache(resource_id, suffix):
     # neither is common usage from many cluster nodes.
     # Encryption is supported on Windows and Mac.
 
-    # FIXME: remove
-    if random.randrange(0, 100) < 5:
-        err = [errno.EAGAIN, errno.ESTALE][random.randrange(0,2)]
-        errstr = os.strerror(err)
-        raise OSError(err, errstr)
     cache = None
     token_path = get_token_path(resource_id, suffix)
     if sys.platform.startswith("linux"):

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -13,6 +13,9 @@ from ._retry_strategy import _log_retry_info, _return_last_value
 from msal_extensions.persistence import FilePersistence
 from msal_extensions.token_cache import PersistedTokenCache
 
+# FIXME: remove
+import random
+
 if not sys.platform.startswith("linux"):
     from msal_extensions import build_encrypted_persistence
 
@@ -99,6 +102,9 @@ def get_token_cache(resource_id, suffix):
     # neither is common usage from many cluster nodes.
     # Encryption is supported on Windows and Mac.
 
+    # FIXME: remove
+    if random.randrange(0, 100) < 80:
+        raise Exception
     cache = None
     token_path = get_token_path(resource_id, suffix)
     if sys.platform.startswith("linux"):

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -109,7 +109,7 @@ def get_token_cache(resource_id, suffix):
     # Encryption is supported on Windows and Mac.
 
     # FIXME: remove
-    if random.randrange(0, 100) < 80:
+    if random.randrange(0, 100) < 5:
         err = [errno.EAGAIN, errno.ESTALE][random.randrange(0,2)]
         errstr = os.strerror(err)
         raise OSError(err, errstr)

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -24,8 +24,9 @@ def scope_for_resource(resource_id):
 
 
 def _maybe_nfs_exception(exception):
-    return isinstance(exception, OSError) and \
-        (exception.errno in (errno.EAGAIN, errno.ESTALE))
+    return isinstance(exception, OSError) and (
+        exception.errno in (errno.EAGAIN, errno.ESTALE)
+    )
 
 
 class AuthProvider:
@@ -35,19 +36,16 @@ class AuthProvider:
         self._app = None
         return
 
-    @tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-              stop=tn.stop_after_attempt(6),
-              wait=(
-                  tn.wait_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-                  + tn.wait_random_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-              ),
-              retry_error_callback=_return_last_value,
-              before_sleep=_log_retry_info,
-              )
+    @tn.retry(
+        retry=tn.retry_if_exception(_maybe_nfs_exception),
+        stop=tn.stop_after_attempt(6),
+        wait=(
+            tn.wait_exponential(multiplier=0.5, exp_base=2)
+            + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+        ),
+        retry_error_callback=_return_last_value,
+        before_sleep=_log_retry_info,
+    )
     def get_token(self):
         accounts = self._app.get_accounts()
         if len(accounts) == 0:
@@ -99,19 +97,16 @@ def get_token_path(resource_id, suffix):
     )
 
 
-@tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-          stop=tn.stop_after_attempt(6),
-          wait=(
-                tn.wait_exponential(
-                    multiplier=0.5, exp_base=2
-                )
-                + tn.wait_random_exponential(
-                    multiplier=0.5, exp_base=2
-                )
-            ),
-            retry_error_callback=_return_last_value,
-            before_sleep=_log_retry_info,
-          )
+@tn.retry(
+    retry=tn.retry_if_exception(_maybe_nfs_exception),
+    stop=tn.stop_after_attempt(6),
+    wait=(
+        tn.wait_exponential(multiplier=0.5, exp_base=2)
+        + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+    ),
+    retry_error_callback=_return_last_value,
+    before_sleep=_log_retry_info,
+)
 def get_token_cache(resource_id, suffix):
     # https://github.com/AzureAD/microsoft-authentication-extensions-\
     # for-python
@@ -145,19 +140,16 @@ def get_token_cache(resource_id, suffix):
     return cache
 
 
-@tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-          stop=tn.stop_after_attempt(6),
-          wait=(
-                tn.wait_exponential(
-                    multiplier=0.5, exp_base=2
-                )
-                + tn.wait_random_exponential(
-                    multiplier=0.5, exp_base=2
-                )
-            ),
-            retry_error_callback=_return_last_value,
-            before_sleep=_log_retry_info,
-          )
+@tn.retry(
+    retry=tn.retry_if_exception(_maybe_nfs_exception),
+    stop=tn.stop_after_attempt(6),
+    wait=(
+        tn.wait_exponential(multiplier=0.5, exp_base=2)
+        + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+    ),
+    retry_error_callback=_return_last_value,
+    before_sleep=_log_retry_info,
+)
 def protect_token_cache(resource_id, suffix):
     token_path = get_token_path(resource_id, suffix)
 
@@ -191,19 +183,16 @@ class AuthProviderInteractive(AuthProvider):
             pass
         return
 
-    @tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-              stop=tn.stop_after_attempt(6),
-              wait=(
-                  tn.wait_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-                  + tn.wait_random_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-              ),
-              retry_error_callback=_return_last_value,
-              before_sleep=_log_retry_info,
-              )
+    @tn.retry(
+        retry=tn.retry_if_exception(_maybe_nfs_exception),
+        stop=tn.stop_after_attempt(6),
+        wait=(
+            tn.wait_exponential(multiplier=0.5, exp_base=2)
+            + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+        ),
+        retry_error_callback=_return_last_value,
+        before_sleep=_log_retry_info,
+    )
     def login(self):
         scopes = [self._scope + " offline_access"]
         login_timeout_minutes = 7
@@ -261,19 +250,16 @@ class AuthProviderDeviceCode(AuthProvider):
             pass
         return
 
-    @tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-              stop=tn.stop_after_attempt(6),
-              wait=(
-                  tn.wait_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-                  + tn.wait_random_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-              ),
-              retry_error_callback=_return_last_value,
-              before_sleep=_log_retry_info,
-              )
+    @tn.retry(
+        retry=tn.retry_if_exception(_maybe_nfs_exception),
+        stop=tn.stop_after_attempt(6),
+        wait=(
+            tn.wait_exponential(multiplier=0.5, exp_base=2)
+            + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+        ),
+        retry_error_callback=_return_last_value,
+        before_sleep=_log_retry_info,
+    )
     def login(self):
         flow = self._app.initiate_device_flow([self._scope])
 
@@ -306,19 +292,16 @@ class AuthProviderManaged(AuthProvider):
         self._scope = scope_for_resource(resource_id)
         return
 
-    @tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-              stop=tn.stop_after_attempt(6),
-              wait=(
-                  tn.wait_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-                  + tn.wait_random_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-              ),
-              retry_error_callback=_return_last_value,
-              before_sleep=_log_retry_info,
-              )
+    @tn.retry(
+        retry=tn.retry_if_exception(_maybe_nfs_exception),
+        stop=tn.stop_after_attempt(6),
+        wait=(
+            tn.wait_exponential(multiplier=0.5, exp_base=2)
+            + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+        ),
+        retry_error_callback=_return_last_value,
+        before_sleep=_log_retry_info,
+    )
     def get_token(self):
         return self._app.get_token(self._scope).token
 
@@ -326,19 +309,16 @@ class AuthProviderManaged(AuthProvider):
 
 
 class AuthProviderSumoToken(AuthProvider):
-    @tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-              stop=tn.stop_after_attempt(6),
-              wait=(
-                  tn.wait_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-                  + tn.wait_random_exponential(
-                      multiplier=0.5, exp_base=2
-                  )
-              ),
-              retry_error_callback=_return_last_value,
-              before_sleep=_log_retry_info,
-              )
+    @tn.retry(
+        retry=tn.retry_if_exception(_maybe_nfs_exception),
+        stop=tn.stop_after_attempt(6),
+        wait=(
+            tn.wait_exponential(multiplier=0.5, exp_base=2)
+            + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+        ),
+        retry_error_callback=_return_last_value,
+        before_sleep=_log_retry_info,
+    )
     def __init__(self, resource_id):
         protect_token_cache(resource_id, ".sharedkey")
         token_path = get_token_path(resource_id, ".sharedkey")
@@ -353,19 +333,16 @@ class AuthProviderSumoToken(AuthProvider):
         return {"X-SUMO-Token": self._token}
 
 
-@tn.retry(retry=tn.retry_if_exception(_maybe_nfs_exception),
-          stop=tn.stop_after_attempt(6),
-          wait=(
-                tn.wait_exponential(
-                    multiplier=0.5, exp_base=2
-                )
-                + tn.wait_random_exponential(
-                    multiplier=0.5, exp_base=2
-                )
-            ),
-            retry_error_callback=_return_last_value,
-            before_sleep=_log_retry_info,
-          )
+@tn.retry(
+    retry=tn.retry_if_exception(_maybe_nfs_exception),
+    stop=tn.stop_after_attempt(6),
+    wait=(
+        tn.wait_exponential(multiplier=0.5, exp_base=2)
+        + tn.wait_random_exponential(multiplier=0.5, exp_base=2)
+    ),
+    retry_error_callback=_return_last_value,
+    before_sleep=_log_retry_info,
+)
 def get_auth_provider(
     client_id,
     authority,

--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -17,7 +17,7 @@ def _log_retry_info(retry_state):
 
 # Define the conditions for retrying based on exception types
 def _is_retryable_exception(exception):
-    return isinstance(exception, (httpx.TimeoutException, httpx.ConnectError,
+    return isinstance(exception, (httpx.TimeoutException, httpx.NetworkError,
                                   httpx.ProxyError))
 
 

--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -17,7 +17,8 @@ def _log_retry_info(retry_state):
 
 # Define the conditions for retrying based on exception types
 def _is_retryable_exception(exception):
-    return isinstance(exception, (httpx.TimeoutException, httpx.ConnectError))
+    return isinstance(exception, (httpx.TimeoutException, httpx.ConnectError,
+                                  httpx.ProxyError))
 
 
 # Define the conditions for retrying based on HTTP status codes
@@ -31,6 +32,7 @@ def _return_last_value(retry_state):
 
 class RetryStrategy:
     def __init__(self, stop_after=6, multiplier=0.5, exp_base=2):
+
         self._stop_after = stop_after
         self._multiplier = multiplier
         self._exp_base = exp_base

--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -17,8 +17,10 @@ def _log_retry_info(retry_state):
 
 # Define the conditions for retrying based on exception types
 def _is_retryable_exception(exception):
-    return isinstance(exception, (httpx.TimeoutException, httpx.NetworkError,
-                                  httpx.ProxyError))
+    return isinstance(
+        exception,
+        (httpx.TimeoutException, httpx.NetworkError, httpx.ProxyError),
+    )
 
 
 # Define the conditions for retrying based on HTTP status codes
@@ -32,7 +34,6 @@ def _return_last_value(retry_state):
 
 class RetryStrategy:
     def __init__(self, stop_after=6, multiplier=0.5, exp_base=2):
-
         self._stop_after = stop_after
         self._multiplier = multiplier
         self._exp_base = exp_base


### PR DESCRIPTION
Mainly to handle EAGAIN and ESTALE errors, commonly caused by NFS problems.

Bonus: handle a few more types of http errors.