### PR TITLE
Fallback to device-code if interactive login times out. Also rearrang…

### DIFF
--- a/src/sumo/wrapper/login.py
+++ b/src/sumo/wrapper/login.py
@@ -74,7 +74,10 @@ def main():
     if args.print_token:
         print(f"TOKEN: {token}")
 
-    print("Successfully logged in to Sumo environment: " + env)
+    if token is not None:
+        print("Successfully logged in to Sumo environment: " + env)
+    else:
+        print("Failed login to Sumo environment: " + env)
 
 
 if __name__ == "__main__":

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -84,6 +84,27 @@ class SumoClient:
             access_token=access_token,
             devicecode=devicecode,
         )
+        if (
+            self.auth.get_token() is None
+            and refresh_token is None
+            and access_token is None
+        ):
+            print("\n \033[31m !!! Falling back to device-code login:\033[0m")
+            self.auth = get_auth_provider(
+                client_id=APP_REGISTRATION[env]["CLIENT_ID"],
+                authority=f"{AUTHORITY_HOST_URI}/{TENANT_ID}",
+                resource_id=APP_REGISTRATION[env]["RESOURCE_ID"],
+                interactive=False,
+                refresh_token=None,
+                access_token=None,
+                devicecode=True,
+            )
+        if self.auth.get_token() is None:
+            print(
+                "\n\n \033[31m "
+                + "NOTE! Login failed/timed out. Giving up."
+                + "\033[0m"
+            )
 
         if env == "localhost":
             self.base_url = "http://localhost:8084/api/v1"


### PR DESCRIPTION
…e device-code login() to be more similar to interactive login(). 

Also reduced the time we wait for end-users to login from 7 tom 5 minutes. 

https://github.com/equinor/sumo-wrapper-python/issues/193 