### PR TITLE
Detect chromium lockfile issue and fallback to device code login

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -1,3 +1,5 @@
+import platform
+from pathlib import Path
 import msal
 import os
 from datetime import datetime, timedelta
@@ -423,5 +425,17 @@ def get_auth_provider(
         ]
     ):
         return AuthProviderManaged(resource_id)
+    # ELSE
+    lockfile_path = Path.home() / ".config/chromium/SingletonLock"
+    if Path(lockfile_path).is_symlink() and not str(
+        Path(lockfile_path).resolve()
+    ).__contains__(platform.node()):
+        # https://github.com/equinor/sumo-wrapper-python/issues/193
+        print(
+            "Chromium lockfile points to another host, "
+            f"you should delete {lockfile_path}. "
+            "Falling back to device-code login now"
+        )
+        return AuthProviderDeviceCode(client_id, authority, resource_id)
     # ELSE
     return AuthProviderInteractive(client_id, authority, resource_id)


### PR DESCRIPTION
$ sumo_login
Login to Sumo environment: prod
Chromium lockfile points to another host, you should delete /private/rowh/.config/chromium/SingletonLock. Falling back to device-code login now
 NOTE! Please login to Equinor Azure to enable Sumo access:To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code xxx to authenticate. 
You should complete your login within5 minutes,that is before12:27:33
