### PR TITLE
feat: add method to create and store a shared access key...

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -67,8 +67,10 @@ class AuthProvider:
         return {"Authorization": "Bearer " + token}
 
     def store_shared_access_key_for_case(self, case_uuid, token):
-        with open(get_token_path(self._resource_id + "+" + case_uuid,
-                                      ".sharedkey"), "w") as f:
+        with open(
+            get_token_path(self._resource_id + "+" + case_uuid, ".sharedkey"),
+            "w",
+        ) as f:
             f.write(token)
 
     pass
@@ -399,7 +401,7 @@ def get_auth_provider(
     access_token=None,
     refresh_token=None,
     devicecode=False,
-    case_uuid = None,
+    case_uuid=None,
 ):
     if refresh_token:
         return AuthProviderRefreshToken(
@@ -409,7 +411,9 @@ def get_auth_provider(
     if access_token:
         return AuthProviderAccessToken(access_token)
     # ELSE
-    if case_uuid is not None and os.path.exists(get_token_path(resource_id + "+" + case_uuid, ".sharedkey")):
+    if case_uuid is not None and os.path.exists(
+        get_token_path(resource_id + "+" + case_uuid, ".sharedkey")
+    ):
         return AuthProviderSumoToken(resource_id + "+" + case_uuid)
     # ELSE
     if os.path.exists(get_token_path(resource_id, ".sharedkey")):

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -66,6 +66,11 @@ class AuthProvider:
 
         return {"Authorization": "Bearer " + token}
 
+    def store_shared_access_key_for_case(self, case_uuid, token):
+        with open(get_token_path(self._resource_id + "+" + case_uuid,
+                                      ".sharedkey"), "w") as f:
+            f.write(token)
+
     pass
 
 
@@ -394,6 +399,7 @@ def get_auth_provider(
     access_token=None,
     refresh_token=None,
     devicecode=False,
+    case_uuid = None,
 ):
     if refresh_token:
         return AuthProviderRefreshToken(
@@ -402,6 +408,9 @@ def get_auth_provider(
     # ELSE
     if access_token:
         return AuthProviderAccessToken(access_token)
+    # ELSE
+    if case_uuid is not None and os.path.exists(get_token_path(resource_id + "+" + case_uuid, ".sharedkey")):
+        return AuthProviderSumoToken(resource_id + "+" + case_uuid)
     # ELSE
     if os.path.exists(get_token_path(resource_id, ".sharedkey")):
         return AuthProviderSumoToken(resource_id)

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -424,9 +424,13 @@ class SumoClient:
     def client_for_case(self, case_uuid):
         """Instantiate and return new SumoClient for accessing the
         case identified by "case_uuid*."""
-        return SumoClient(env=self.env, verbosity=self._verbosity,
-                          retry_strategy=self._retry_strategy,
-                          timeout=self._timeout, case_uuid=case_uuid)
+        return SumoClient(
+            env=self.env,
+            verbosity=self._verbosity,
+            retry_strategy=self._retry_strategy,
+            timeout=self._timeout,
+            case_uuid=case_uuid,
+        )
 
     @raise_for_status_async
     async def get_async(self, path: str, params: dict = None):

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -423,7 +423,7 @@ class SumoClient:
 
     def client_for_case(self, case_uuid):
         """Instantiate and return new SumoClient for accessing the
-        case identified by "case_uuid*."""
+        case identified by *case_uuid*."""
         return SumoClient(
             env=self.env,
             verbosity=self._verbosity,

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -33,7 +33,7 @@ class SumoClient:
         verbosity: str = "CRITICAL",
         retry_strategy=RetryStrategy(),
         timeout=DEFAULT_TIMEOUT,
-        case_uuid = None,
+        case_uuid=None,
     ):
         """Initialize a new Sumo object
 
@@ -86,7 +86,7 @@ class SumoClient:
             refresh_token=refresh_token,
             access_token=access_token,
             devicecode=devicecode,
-            case_uuid = case_uuid,
+            case_uuid=case_uuid,
         )
 
         if env == "localhost":
@@ -413,7 +413,9 @@ class SumoClient:
         Side effects:
             Creates a new file in ~/.sumo, named {app_id}+{case_uuid}
         """
-        token = self.get(f"/objects('{case_uuid}')/make-shared-access-key").text
+        token = self.get(
+            f"/objects('{case_uuid}')/make-shared-access-key"
+        ).text
         self.auth.store_shared_access_key_for_case(case_uuid, token)
 
     @raise_for_status_async

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -33,6 +33,7 @@ class SumoClient:
         verbosity: str = "CRITICAL",
         retry_strategy=RetryStrategy(),
         timeout=DEFAULT_TIMEOUT,
+        case_uuid = None,
     ):
         """Initialize a new Sumo object
 
@@ -85,6 +86,7 @@ class SumoClient:
             refresh_token=refresh_token,
             access_token=access_token,
             devicecode=devicecode,
+            case_uuid = case_uuid,
         )
 
         if env == "localhost":
@@ -397,6 +399,22 @@ class SumoClient:
             logger.addHandler(handler)
             pass
         return logger
+
+    def create_shared_access_key_for_case(self, case_uuid):
+        """Creates and stores a shared access key that can be used to access
+        the case identified by *case_uuid*, in the current Sumo environment.
+
+        This shared access key can then be used by instantiating
+        SumoClient with the parameter case_uuid set accordingly.
+
+        Args:
+            case_uuid: the uuid for a case.
+
+        Side effects:
+            Creates a new file in ~/.sumo, named {app_id}+{case_uuid}
+        """
+        token = self.get(f"/objects('{case_uuid}')/make-shared-access-key").text
+        self.auth.store_shared_access_key_for_case(case_uuid, token)
 
     @raise_for_status_async
     async def get_async(self, path: str, params: dict = None):

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -51,6 +51,7 @@ class SumoClient:
             raise ValueError(f"Invalid environment: {env}")
 
         self.env = env
+        self._verbosity = verbosity
 
         self._retry_strategy = retry_strategy
         self._client = httpx.Client()
@@ -419,6 +420,13 @@ class SumoClient:
             f"/objects('{case_uuid}')/make-shared-access-key"
         ).text
         self.auth.store_shared_access_key_for_case(case_uuid, token)
+
+    def client_for_case(self, case_uuid):
+        """Instantiate and return new SumoClient for accessing the
+        case identified by "case_uuid*."""
+        return SumoClient(env=self.env, verbosity=self._verbosity,
+                          retry_strategy=self._retry_strategy,
+                          timeout=self._timeout, case_uuid=case_uuid)
 
     @raise_for_status_async
     async def get_async(self, path: str, params: dict = None):

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -50,6 +50,8 @@ class SumoClient:
         if env not in APP_REGISTRATION:
             raise ValueError(f"Invalid environment: {env}")
 
+        self.env = env
+
         self._retry_strategy = retry_strategy
         self._client = httpx.Client()
         self._async_client = httpx.AsyncClient()


### PR DESCRIPTION
 for a specific case, and extend the constructor to allow the use of this key.

The main intended use for this is by `fmu-sumo-uploader`, but it may have other uses.


Example use:

```
from sumo.wrapper import SumoClient

sumo=SumoClient(env="dev")
sumo.create_shared_access_key_for_case("388f3dd9-a219-4131-a6b3-c6a3b671257a")

...

sumo=SumoClient(env="dev", case_uuid="388f3dd9-a219-4131-a6b3-c6a3b671257a")
# The SumoClient instance sumo now has only access to objects belonging to the case 
# with uuid="388f3dd9-a219-4131-a6b3-c6a3b671257a"
```