### PR TITLE
Fixes for support of shared access keys

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -93,7 +93,7 @@ class AuthProviderAccessToken(AuthProvider):
         self._access_token = access_token
         payload = jwt.decode(access_token, options={"verify_signature": False})
         self._expires = payload["exp"]
-        self._resource_id=payload["aud"]
+        self._resource_id = payload["aud"]
         return
 
     def get_token(self):


### PR DESCRIPTION
- Fix for protect_token_cache.
- Refactor.
- Added _resource_id to AuthProviderAccessToken so that it can be used to create shared access keys (required for PR tests on github).