### PR TITLE
chore: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: build
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-13]
     permissions:
       contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python",
 ]
 authors = [{ name = "Equinor" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
   "msal>=1.20.0",
@@ -47,21 +47,12 @@ sumo_login = "sumo.wrapper.login:main"
 where = ["src"]
 
 [tool.ruff]
-exclude = [
-  ".env",
-  ".git",
-  ".github",
-  ".venv",
-  "venv",
-]
+exclude = [".env", ".git", ".github", ".venv", "venv"]
 
 line-length = 79
 
 [tool.ruff.lint]
-ignore = [
-  "E501",
-  "N802",
-]
+ignore = ["E501", "N802"]
 
 extend-select = [
   "C4",  # Flake8-comprehensions
@@ -74,4 +65,3 @@ extend-select = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
-


### PR DESCRIPTION
Our other packages no longer support Python 3.8.
Wrapper should follow suit.