### PR TITLE
feat: remove stale shared keys.

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -31,19 +31,17 @@ def _maybe_nfs_exception(exception):
 
 
 def get_token_dir():
-    return os.path.join(os.path.expanduser("~"), ".sumo")
+    return os.path.expanduser("~/.sumo")
 
 
 def get_token_path(resource_id, suffix, case_uuid=None):
     if case_uuid is not None:
         return os.path.join(
-            os.path.expanduser("~/.sumo"),
+            get_token_dir(),
             str(resource_id) + "+" + str(case_uuid) + suffix,
         )
     else:
-        return os.path.join(
-            os.path.expanduser("~/.sumo"), str(resource_id) + suffix
-        )
+        return os.path.join(get_token_dir(), str(resource_id) + suffix)
 
 
 class AuthProvider:
@@ -94,7 +92,9 @@ class AuthProvider:
         return
 
     def cleanup_shared_keys(self):
-        tokendir = os.path.join(os.path.expanduser("~/.sumo"))
+        tokendir = get_token_dir()
+        if not os.path.exists(tokendir):
+            return
         for f in os.listdir(tokendir):
             ff = os.path.join(tokendir, f)
             if os.path.isfile(ff):

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -92,7 +92,7 @@ class AuthProvider:
             f.write(token)
         protect_token_cache(self._resource_id, ".sharedkey", case_uuid)
         return
-    
+
     def cleanup_shared_keys(self):
         tokendir = os.path.join(os.path.expanduser("~/.sumo"))
         for f in os.listdir(tokendir):
@@ -105,7 +105,9 @@ class AuthProvider:
                             token = file.read()
                             pq = parse_qs(token)
                             se = pq["se"][0]
-                            end = datetime.strptime(se, "%Y-%m-%dT%H:%M:%S.%fZ")
+                            end = datetime.strptime(
+                                se, "%Y-%m-%dT%H:%M:%S.%fZ"
+                            )
                             now = datetime.utcnow()
                             if now > end:
                                 os.unlink(ff)

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -92,6 +92,8 @@ class SumoClient:
             case_uuid=case_uuid,
         )
 
+        self.auth.cleanup_shared_keys()
+
         if env == "localhost":
             self.base_url = "http://localhost:8084/api/v1"
         else:


### PR DESCRIPTION
In the SumoClient constructor, ask the AuthProvider instance to remove any stale (expired) `.sharedkey` tokens.