### PR TITLE
fix: do not retry on status code 504 (proxy timeout).

### DIFF
--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -30,7 +30,7 @@ def _is_retryable_exception(exception):
 
 # Define the conditions for retrying based on HTTP status codes
 def _is_retryable_status_code(response):
-    return response.status_code in [502, 503, 504]
+    return response.status_code in [502, 503]
 
 
 def _return_last_value(retry_state):


### PR DESCRIPTION
The aggregation service may, in som cases, take more than a minute to provide results. When that happens, radix (or the nginx reverse proxy) returns the status code 504. If the operation is retried, the aggregation server starts a new thread serving the same operation, potentially (eventually) overloading the server.