### PR TITLE
feat: poll api

### DIFF
--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -429,7 +429,7 @@ class SumoClient:
             A new httpx.response object.
         """
         location, retry_after = self._get_retry_details(response_in)
-        expiry = time.time() + expiry if timeout is not None else None
+        expiry = time.time() + timeout if timeout is not None else None
         while True:
             time.sleep(retry_after)
             response = self.get(location)
@@ -725,7 +725,7 @@ class SumoClient:
             A new httpx.response object.
         """
         location, retry_after = self._get_retry_details(response_in)
-        expiry = time.time() + expiry if timeout is not None else None
+        expiry = time.time() + timeout if timeout is not None else None
         while True:
             await asyncio.sleep(retry_after)
             response = await self.get_async(location)

--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -414,7 +414,6 @@ class SumoClient:
         assert retry_after is not None, "Missing header: Retry-After"
         location = location[len(self.base_url) :]
         retry_after = int(retry_after)
-        retry_after = 10
         return location, retry_after
 
     def poll(

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -112,9 +112,13 @@ def test_upload_search_delete_ensemble_child(token):
 
     fmu_surface_metadata["fmu"]["case"]["uuid"] = case_uuid
 
-    response_surface = _upload_child_level_json(
-        conn=sumo_client, parent_id=case_id, json=fmu_surface_metadata
-    )
+    try:
+        response_surface = _upload_child_level_json(
+            conn=sumo_client, parent_id=case_id, json=fmu_surface_metadata
+        )
+    except Exception as ex:
+        print(ex.response.text)
+        raise ex
 
     assert 200 <= response_surface.status_code <= 202
     assert isinstance(response_surface.json(), dict)

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -237,3 +237,12 @@ def test_upload_duplicate_ensemble(token):
     # Search for ensemble
     with pytest.raises(Exception):
         assert _download_object(conn, object_id=case_id2)
+
+
+def test_poll(token):
+    conn = SumoClient(env="dev", token=token)
+    res = conn.get("/admin/index/orphans")
+    res2 = conn.poll(res)
+    assert res2.status_code == 200
+    indexorphans = res2.json()
+    assert type(indexorphans) == list

--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -245,4 +245,4 @@ def test_poll(token):
     res2 = conn.poll(res)
     assert res2.status_code == 200
     indexorphans = res2.json()
-    assert type(indexorphans) == list
+    assert isinstance(indexorphans, list)

--- a/tests/testdata/surface.yml
+++ b/tests/testdata/surface.yml
@@ -75,7 +75,7 @@ fmu:
 file:
   relative_path: realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri # case-relative
   absolute_path: /some/absolute/path//realization-33/iter-0/share/results/maps/volantis_gp_base--amplitude.gri
-  checksum_md5: kjhsdfvsdlfk23knerknvk23  # checksum of the file, not the data.
+  checksum_md5: 0123456789abcdef0123456789abcdef  # checksum of the file, not the data.
 
 data: # The data block describes the actual data (e.g. surface). Only present in data objects
 


### PR DESCRIPTION
New methods `poll` and `poll_async`. These are meant to be used with long-running requests that run asynchronously; the response from these requests include the headers `Location` and `Retry-After` that tell the client where to look for the result of the request, and how long to wait before checking for a result.

Example:

```
def get_index_orphans(conn: SumoClient):
    res = conn.get("/admin/index/orphans")
    res2  = conn.poll(res)
    assert res2.status_code == 200
    indexorphans = res2.json()
    assert type(indexorphans) == list
```