### PR TITLE
feat: use firefox if chromium is locked

### DIFF
--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -449,7 +449,9 @@ def get_auth_provider(
             Path(lockfile_path).resolve()
         ).__contains__(platform.node()):
             # https://github.com/equinor/sumo-wrapper-python/issues/193
-            print("\n\n\033[1mDetected chromium lockfile for different node; using firefox to authenticate.\033[0m")
+            print(
+                "\n\n\033[1mDetected chromium lockfile for different node; using firefox to authenticate.\033[0m"
+            )
             os.environ["BROWSER"] = "firefox"
             pass
 

--- a/src/sumo/wrapper/_auth_provider.py
+++ b/src/sumo/wrapper/_auth_provider.py
@@ -1,10 +1,12 @@
 import errno
 import json
 import os
+import platform
 import stat
 import sys
 import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from urllib.parse import parse_qs
 
 import jwt
@@ -441,6 +443,16 @@ def get_auth_provider(
         pass
     # ELSE
     if interactive:
+        lockfile_path = Path.home() / ".config/chromium/SingletonLock"
+
+        if Path(lockfile_path).is_symlink() and not str(
+            Path(lockfile_path).resolve()
+        ).__contains__(platform.node()):
+            # https://github.com/equinor/sumo-wrapper-python/issues/193
+            print("\n\n\033[1mDetected chromium lockfile for different node; using firefox to authenticate.\033[0m")
+            os.environ["BROWSER"] = "firefox"
+            pass
+
         return AuthProviderInteractive(client_id, authority, resource_id)
     # ELSE
     if devicecode:

--- a/src/sumo/wrapper/login.py
+++ b/src/sumo/wrapper/login.py
@@ -1,7 +1,5 @@
 import logging
-import platform
 from argparse import ArgumentParser
-from pathlib import Path
 
 from sumo.wrapper import SumoClient
 
@@ -68,16 +66,6 @@ def main():
 
     if mode != "silent":
         print("Login to Sumo environment: " + env)
-
-    if mode == "interactive":
-        lockfile_path = Path.home() / ".config/chromium/SingletonLock"
-
-        if Path(lockfile_path).is_symlink() and not str(
-            Path(lockfile_path).resolve()
-        ).__contains__(platform.node()):
-            # https://github.com/equinor/sumo-wrapper-python/issues/193
-            is_interactive = False
-            is_devicecode = True
 
     sumo = SumoClient(
         env,


### PR DESCRIPTION
Previously, we had a fallback to device-code authentication if we found a lockfile for chromium. Since we're not allowed to use device-code authentication, we just use firefox for interactive authentication.