### PR TITLE
chore: drop support for python 3.9 and 3.10

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,7 +1,7 @@
-# Build the docs here, to show errors. 
-# The actual deployment of docs is configured in ReadTheDocs.org. 
+# Build the docs here, to show errors.
+# The actual deployment of docs is configured in ReadTheDocs.org.
 
-name: Build and deploy docs 
+name: Build and deploy docs
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-13]
     permissions:
       contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python",
 ]
 authors = [{ name = "Equinor" }]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "msal>=1.20.0",


### PR DESCRIPTION
Closes #236 

Probably bump version `1.0.29` -> `1.1.0` with this change?