### PR TITLE
fix: build readthedocs using python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,16 +1,16 @@
 version: 2
 
 build:
-    os: ubuntu-22.04
-    tools:
-        python: "3.10"
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
 
 python:
-    install:
-        - method: pip
-          path: .
-          extra_requirements:
-            - docs
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
 
 sphinx:
-    configuration: docs/conf.py
+  configuration: docs/conf.py


### PR DESCRIPTION
Build fails since Python 3.10 is no longer supported.
Update to build using 3.12.