### PR TITLE
feat: use dns alias as base url for Prod

### DIFF
--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -113,11 +113,12 @@ class SumoClient:
             case_uuid=case_uuid,
         )
 
-        if env == "localhost":
+        if env == "prod":
+            self.base_url = "https://api.sumo.equinor.com/api/v1"
+        elif env == "localhost":
             self.base_url = "http://localhost:8084/api/v1"
         else:
             self.base_url = f"https://main-sumo-{env}.radix.equinor.com/api/v1"
-            pass
         return
 
     def __enter__(self):


### PR DESCRIPTION
Related to https://github.com/equinor/sumo-core/issues/794

This will ensure that clients using the wrapper always have a valid URL (for Prod)
We can then configure where the URL points and change it without requiring user updates.

Currently `api.sumo.equinor.com` is pointing to Sumo-core in the default Radix cluster.
Will be updated to point to Sumo-core in Swedencentral when we move.

Not sure if this is the best way to implement this or if we can do it in a smarter way. Open for suggestions.
The crucial part is that the next version of Komodo has a Wrapper that uses the new alias.

To be discussed:
This will break for clients in non-prod environments unless:
- We have separate simple URLs for the other envs (don't think this is preferable)
- Or we update the base_url here when we switch to the new Radix cluster. (Think this is the preferred solution. Probably ok to require non-prod users to install the newest version of the Wrapper, regardless of the update being in Komodo or not)