### PR TITLE
chore: update macos test runner image to macos-15

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The `macos-13` base runner image is deprecated.