### PR TITLE
fix: tests expect task response

### DIFF
--- a/tests/test_sumo_thin_client.py
+++ b/tests/test_sumo_thin_client.py
@@ -50,8 +50,7 @@ def _upload_child_level_json(conn, parent_id, json):
 
 
 def _delete_object(conn, object_id):
-    response = conn.delete(f"/objects('{object_id}')").json()
-
+    response = conn.delete(f"/objects('{object_id}')")
     return response
 
 
@@ -144,7 +143,7 @@ def test_upload_search_delete_ensemble_child(token):
 
     # Delete Ensemble
     result = _delete_object(conn=sumo_client, object_id=case_id)
-    assert result == "Accepted"
+    assert result.text == "Accepted."
 
     sleep(40)
 
@@ -210,7 +209,7 @@ def test_upload_duplicate_ensemble(token):
     # Delete Ensemble
     sleep(5)
     result = _delete_object(conn=conn, object_id=case_id1)
-    assert result == "Accepted"
+    assert result.text == "Accepted."
 
     # Ugly: sumo-core has a cache for case objects, which has a
     # time-to-live of 60 seconds. If there are multiple replicas


### PR DESCRIPTION
 ## Issue
Closes #262 

## Description
Sumo-core was updated to handle case deletes as a Task: https://github.com/equinor/sumo-core/pull/994
Update the tests to expect the new response.
- Do not try to convert to json
- Assert response text is "Accepted."

## How to test
Run the two tests that were failing `test_upload_duplicate_ensemble` and `test_upload_search_delete_ensemble_child` and see that they pass.

(The tests are also run as part of the PR checks here)

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅