### PR TITLE
fix: add cache for config data from the 'WELL_KNOWN' endpoint.

### DIFF
--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -26,6 +26,8 @@ WELL_KNOWN = os.environ.get(
     "SUMOCONNECTIONINFO", "https://api.sumo.equinor.com/well-known"
 )
 
+well_known = None
+
 
 class SumoClient:
     """Authenticate and perform requests to the Sumo API."""
@@ -70,8 +72,9 @@ class SumoClient:
         """
 
         logger.setLevel(verbosity)
-
-        well_known = httpx.get(WELL_KNOWN).json()
+        global well_known
+        if well_known is None:
+            well_known = httpx.get(WELL_KNOWN).json()
         if env not in well_known["envs"]:
             raise ValueError(f"Invalid environment: {env}")
 


### PR DESCRIPTION
 ## Issue
Closes #263 

## Description
Add a global variable for caching config data from the `WELL_KNOWN` endpoint.

## How to test

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [x] Documentation has been updated 🧾
- [x] Commits are semantic ✅