### PR TITLE
feat: default interactive false in client_for_case

### DIFF
--- a/src/sumo/wrapper/sumo_client.py
+++ b/src/sumo/wrapper/sumo_client.py
@@ -522,7 +522,7 @@ class SumoClient:
         ).text
         self.auth.store_shared_access_key_for_case(case_uuid, token)
 
-    def client_for_case(self, case_uuid):
+    def client_for_case(self, case_uuid, interactive=False):
         """Instantiate and return new SumoClient for accessing the
         case identified by *case_uuid*."""
         if self.auth.has_case_token(case_uuid):
@@ -532,6 +532,7 @@ class SumoClient:
                 retry_strategy=self._retry_strategy,
                 timeout=self._timeout,
                 case_uuid=case_uuid,
+                interactive=interactive,
             )
         else:
             return self


### PR DESCRIPTION
 ## Issue
Closes https://github.com/equinor/sumo-core/issues/1036

## Description
Related to https://github.com/equinor/fmu-sumo-uploader/pull/230
When trying to authenticate using a case `sharedkey` we do not want to fall back to interactive login if it fails.

## How to test
Run a Drogon case without the `--sumo` flag in `create_case_metadata`
Error message should be 404 instead of 401

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅