### PR TITLE
feat: log details to message log

### DIFF
--- a/src/sumo/wrapper/_logging.py
+++ b/src/sumo/wrapper/_logging.py
@@ -28,6 +28,9 @@ class LogHandlerSumo(logging.Handler):
             if "objectUuid" in record.__dict__:
                 json["objectUuid"] = record.__dict__.get("objectUuid")
 
+            if "details" in record.__dict__:
+                json["details"] = record.__dict__.get("details")
+
             self._sumoClient.post("/message-log/new", json=json)
         except Exception:
             # Never fail on logging


### PR DESCRIPTION
to be used for example from the fmu-sumo-uplader
to include a summary of the upload with the logs

 ## Issue
[#fmu-sumo-uploader/issues/219](https://github.com/equinor/fmu-sumo-uploader/issues/219)

## Description
Necessary change to make use of details provided when logging.

## How to test
From a library using the LogHandlerSumo, such as fmu-sumo-uploader, make a logging, such as

```python

details = {
    "caseuuid": "1234-5678",
    "ensamblename": "my_ensamble",
    "numbers_of_objects_uploaded": "42",
    "start_time": "2026-06-04T12:00:00Z",
    "end_time": "2026-06-04T12:30:00Z",
}

logger.info("Upload finished",  extra={"details": details})

```

And observe that data is stored in the message log.


## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [ ] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅