### PR TITLE
feat: add before_sleep as constructor arg to RetryStrategy.

### DIFF
--- a/src/sumo/wrapper/_retry_strategy.py
+++ b/src/sumo/wrapper/_retry_strategy.py
@@ -38,10 +38,17 @@ def _return_last_value(retry_state):
 
 
 class RetryStrategy:
-    def __init__(self, stop_after=6, multiplier=0.5, exp_base=2):
+    def __init__(
+        self,
+        stop_after=6,
+        multiplier=0.5,
+        exp_base=2,
+        before_sleep=_log_retry_info,
+    ):
         self._stop_after = stop_after
         self._multiplier = multiplier
         self._exp_base = exp_base
+        self._before_sleep = before_sleep
         return
 
     def make_retryer(self) -> tn.Retrying:
@@ -60,7 +67,7 @@ class RetryStrategy:
                 )
             ),
             retry_error_callback=_return_last_value,
-            before_sleep=_log_retry_info,
+            before_sleep=self._before_sleep,
         )
 
     def make_retryer_async(self) -> tn.AsyncRetrying:
@@ -79,5 +86,5 @@ class RetryStrategy:
                 )
             ),
             retry_error_callback=_return_last_value,
-            before_sleep=_log_retry_info,
+            before_sleep=self._before_sleep,
         )


### PR DESCRIPTION
 ## Issue
N/A
## Description
For the uploader, we want to capture the number of retries for uploads. We can do that through the `before_sleep` argument to `tenacity.Retrying` / `tenacity.AsyncRetrying`: we can pass a closure that modifies a `dict`/`list/`object`.
## How to test
The default value for this argument is the same as what we previously hardcoded, so there should be no difference in behaviour.
## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [x] Documentation has been updated 🧾
- [x] Commits are semantic ✅